### PR TITLE
Allow to propose new block with reorg

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1668,7 +1668,6 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 
 		// Create a new developer genesis block or reuse existing one
 		cfg.Genesis = readGenesis(ctx.String(GenesisPathFlag.Name))
-		log.Info("@@@@@@", "bedrockBlock", cfg.Genesis.Config.BedrockBlock)
 		//log.Info("Using custom developer period", "seconds", cfg.Genesis.Config.Clique.Period)
 	}
 

--- a/eth/stagedsync/stage_mining_create_block.go
+++ b/eth/stagedsync/stage_mining_create_block.go
@@ -123,15 +123,24 @@ func SpawnMiningCreateBlockStage(s *StageState, tx kv.RwTx, cfg MiningCreateBloc
 				return err
 			}
 			executionAt = exectedParent.Number.Uint64()
-			err = s.Update(tx, executionAt)
+			parent = exectedParent
+
+			err = stages.SaveStageProgress(tx, stages.MiningCreateBlock, executionAt)
 			if err != nil {
 				return err
 			}
-			parent = exectedParent
-
-			stages.SaveStageProgress(tx, stages.MiningExecution, executionAt)
-			stages.SaveStageProgress(tx, stages.HashState, executionAt)
-			stages.SaveStageProgress(tx, stages.IntermediateHashes, executionAt)
+			err = stages.SaveStageProgress(tx, stages.MiningExecution, executionAt)
+			if err != nil {
+				return err
+			}
+			err = stages.SaveStageProgress(tx, stages.HashState, executionAt)
+			if err != nil {
+				return err
+			}
+			err = stages.SaveStageProgress(tx, stages.IntermediateHashes, executionAt)
+			if err != nil {
+				return err
+			}
 			log.Info("updated executionAt", "executionAt", executionAt)
 		} else {
 			return fmt.Errorf("wrong head block: %x (current) vs %x (requested)", parent.Hash(), cfg.blockBuilderParameters.ParentHash)

--- a/eth/stagedsync/stage_mining_create_block.go
+++ b/eth/stagedsync/stage_mining_create_block.go
@@ -125,20 +125,16 @@ func SpawnMiningCreateBlockStage(s *StageState, tx kv.RwTx, cfg MiningCreateBloc
 			executionAt = exectedParent.Number.Uint64()
 			parent = exectedParent
 
-			err = stages.SaveStageProgress(tx, stages.MiningCreateBlock, executionAt)
-			if err != nil {
+			if err = stages.SaveStageProgress(tx, stages.MiningCreateBlock, executionAt); err != nil {
 				return err
 			}
-			err = stages.SaveStageProgress(tx, stages.MiningExecution, executionAt)
-			if err != nil {
+			if err = stages.SaveStageProgress(tx, stages.MiningExecution, executionAt); err != nil {
 				return err
 			}
-			err = stages.SaveStageProgress(tx, stages.HashState, executionAt)
-			if err != nil {
+			if err = stages.SaveStageProgress(tx, stages.HashState, executionAt); err != nil {
 				return err
 			}
-			err = stages.SaveStageProgress(tx, stages.IntermediateHashes, executionAt)
-			if err != nil {
+			if err = stages.SaveStageProgress(tx, stages.IntermediateHashes, executionAt); err != nil {
 				return err
 			}
 			log.Info("updated executionAt", "executionAt", executionAt)

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -95,7 +95,7 @@ func SpawnMiningExecStage(s *StageState, tx kv.RwTx, cfg MiningExecCfg, quit <-c
 	forceTxs := current.ForceTxs
 	noempty := true
 
-	stateReader := state.NewPlainStateReader(tx)
+	stateReader := state.NewPlainState(tx, current.Header.Number.Uint64(), nil)
 	ibs := state.New(stateReader)
 	stateWriter := state.NewPlainStateWriter(tx, tx, current.Header.Number.Uint64())
 	if cfg.chainConfig.DAOForkSupport && cfg.chainConfig.DAOForkBlock != nil && cfg.chainConfig.DAOForkBlock.Cmp(current.Header.Number) == 0 {

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -95,7 +95,7 @@ func SpawnMiningExecStage(s *StageState, tx kv.RwTx, cfg MiningExecCfg, quit <-c
 	forceTxs := current.ForceTxs
 	noempty := true
 
-	stateReader := state.NewPlainState(tx, current.Header.Number.Uint64(), nil)
+	stateReader := state.NewPlainState(tx, current.Header.Number.Uint64(), systemcontracts.SystemContractCodeLookup[cfg.chainConfig.ChainName])
 	ibs := state.New(stateReader)
 	stateWriter := state.NewPlainStateWriter(tx, tx, current.Header.Number.Uint64())
 	if cfg.chainConfig.DAOForkSupport && cfg.chainConfig.DAOForkBlock != nil && cfg.chainConfig.DAOForkBlock.Cmp(current.Header.Number) == 0 {


### PR DESCRIPTION
According to [Ethereum engine API spec](https://github.com/ethereum/execution-apis/blob/769c53c94c4e487337ad0edea9ee0dce49c79bfa/src/engine/specification.md#engine_forkchoiceupdatedv1), `engine_forkchoiceUpdatedV1` with payload building is not allowed if `forkchoiceState.headBlockHash` is not a leaf of the block tree(head of blockchain).

But in the case of Optimism, [it should be allowed to handle L2 reorg](https://github.com/ethereum-optimism/optimism/blob/develop/specs/derivation.md#l1-consolidation-payload-attributes-matching).

We already have the [patch](https://github.com/testinprod-io/erigon/blob/op-erigon/ethdb/privateapi/ethbackend.go#L636) to allow this case, but handling l2-reorg was failed due to another double-check code in `mining_create_block` stage.

This PR fixes the behavior and contains more patch to handle reorg properly.