### PR TITLE
Fix ots API - Phase 1

### DIFF
--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -37,8 +37,7 @@ import (
 )
 
 func (api *BaseAPI) getReceipts(ctx context.Context, tx kv.Tx, chainConfig *chain.Config, block *types.Block, senders []common.Address) (types.Receipts, error) {
-	// if cached := rawdb.ReadReceipts(api._chainConfig, tx, block, senders); cached != nil {
-	if cached := rawdb.ReadReceipts(api._chainConfig, tx, block, block.Body().SendersFromTxs()); cached != nil {
+	if cached := rawdb.ReadReceipts(api._chainConfig, tx, block, senders); cached != nil {
 		return cached, nil
 	}
 	engine := api.engine()

--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -37,7 +37,8 @@ import (
 )
 
 func (api *BaseAPI) getReceipts(ctx context.Context, tx kv.Tx, chainConfig *chain.Config, block *types.Block, senders []common.Address) (types.Receipts, error) {
-	if cached := rawdb.ReadReceipts(api._chainConfig, tx, block, senders); cached != nil {
+	// if cached := rawdb.ReadReceipts(api._chainConfig, tx, block, senders); cached != nil {
+	if cached := rawdb.ReadReceipts(api._chainConfig, tx, block, block.Body().SendersFromTxs()); cached != nil {
 		return cached, nil
 	}
 	engine := api.engine()

--- a/cmd/rpcdaemon/commands/otterscan_api.go
+++ b/cmd/rpcdaemon/commands/otterscan_api.go
@@ -425,6 +425,9 @@ func (api *OtterscanAPIImpl) SearchTransactionsAfter(ctx context.Context, addr c
 
 func (api *OtterscanAPIImpl) traceBlocks(ctx context.Context, addr common.Address, chainConfig *chain.Config, pageSize, resultCount uint16, callFromToProvider BlockProvider) ([]*TransactionsWithReceipts, bool, error) {
 	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+	traceCtx, traceCtxCancel := context.WithCancel(context.Background())
+	defer traceCtxCancel()
 
 	// Estimate the common case of user address having at most 1 interaction/block and
 	// trace N := remaining page matches as number of blocks to trace concurrently.
@@ -448,10 +451,12 @@ func (api *OtterscanAPIImpl) traceBlocks(ctx context.Context, addr common.Addres
 
 		wg.Add(1)
 		totalBlocksTraced++
-		go api.searchTraceBlock(ctx, &wg, addr, chainConfig, i, nextBlock, results)
+		go api.searchTraceBlock(ctx, traceCtx, traceCtxCancel, &wg, errCh, addr, chainConfig, i, nextBlock, results)
 	}
 	wg.Wait()
-
+	if traceCtx.Err() != nil && len(errCh) == 1 {
+		return nil, false, <-errCh
+	}
 	return results[:totalBlocksTraced], hasMore, nil
 }
 

--- a/cmd/rpcdaemon/commands/otterscan_api.go
+++ b/cmd/rpcdaemon/commands/otterscan_api.go
@@ -570,6 +570,10 @@ func (api *OtterscanAPIImpl) GetBlockTransactions(ctx context.Context, number rp
 		return nil, err
 	}
 
+	if len(senders) != b.Transactions().Len() {
+		// fallback; set senders from inspecting tx
+		senders = b.Body().SendersFromTxs()
+	}
 	// Receipts
 	receipts, err := api.getReceipts(ctx, tx, chainConfig, b, senders)
 	if err != nil {

--- a/cmd/rpcdaemon/commands/otterscan_block_details.go
+++ b/cmd/rpcdaemon/commands/otterscan_block_details.go
@@ -19,6 +19,10 @@ func (api *OtterscanAPIImpl) GetBlockDetails(ctx context.Context, number rpc.Blo
 	defer tx.Rollback()
 
 	b, senders, err := api.getBlockWithSenders(ctx, number, tx)
+	if len(senders) != b.Transactions().Len() {
+		// fallback; set senders from inspecting tx
+		senders = b.Body().SendersFromTxs()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rpcdaemon/commands/otterscan_contract_creator.go
+++ b/cmd/rpcdaemon/commands/otterscan_contract_creator.go
@@ -298,6 +298,11 @@ func (api *OtterscanAPIImpl) GetContractCreator(ctx context.Context, addr common
 		return nil, err
 	}
 
+	// TODO: check if precompiled contract
+	if !tracer.Found() {
+		return nil, nil
+	}
+
 	return &ContractCreatorData{
 		Tx:      tracer.Tx.Hash(),
 		Creator: tracer.Creator,

--- a/cmd/rpcdaemon/commands/otterscan_generic_tracer.go
+++ b/cmd/rpcdaemon/commands/otterscan_generic_tracer.go
@@ -89,6 +89,7 @@ func (api *OtterscanAPIImpl) genericTracer(dbtx kv.Tx, ctx context.Context, bloc
 		msg, _ := tx.AsMessage(*signer, header.BaseFee, rules)
 
 		BlockContext := core.NewEVMBlockContext(header, core.GetHashFn(header, getHeader), engine, nil)
+		BlockContext.L1CostFunc = types.NewL1CostFunc(chainConfig, ibs)
 		TxContext := core.NewEVMTxContext(msg)
 
 		vmenv := vm.NewEVM(BlockContext, TxContext, ibs, chainConfig, vm.Config{Debug: true, Tracer: tracer})

--- a/cmd/rpcdaemon/commands/otterscan_search_trace.go
+++ b/cmd/rpcdaemon/commands/otterscan_search_trace.go
@@ -86,6 +86,7 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.Tx, ctx context.Context, blockNu
 
 		tracer := NewTouchTracer(searchAddr)
 		BlockContext := core.NewEVMBlockContext(header, core.GetHashFn(header, getHeader), engine, nil)
+		BlockContext.L1CostFunc = types.NewL1CostFunc(chainConfig, ibs)
 		TxContext := core.NewEVMTxContext(msg)
 
 		vmenv := vm.NewEVM(BlockContext, TxContext, ibs, chainConfig, vm.Config{Debug: true, Tracer: tracer})

--- a/cmd/rpcdaemon/commands/otterscan_search_trace.go
+++ b/cmd/rpcdaemon/commands/otterscan_search_trace.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/ledgerwatch/erigon-lib/chain"
@@ -18,7 +19,7 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/shards"
 )
 
-func (api *OtterscanAPIImpl) searchTraceBlock(ctx context.Context, wg *sync.WaitGroup, addr common.Address, chainConfig *chain.Config, idx int, bNum uint64, results []*TransactionsWithReceipts) {
+func (api *OtterscanAPIImpl) searchTraceBlock(ctx, traceCtx context.Context, traceCtxCancel context.CancelFunc, wg *sync.WaitGroup, errCh chan<- error, addr common.Address, chainConfig *chain.Config, idx int, bNum uint64, results []*TransactionsWithReceipts) {
 	defer wg.Done()
 
 	// Trace block for Txs
@@ -30,7 +31,19 @@ func (api *OtterscanAPIImpl) searchTraceBlock(ctx context.Context, wg *sync.Wait
 	}
 	defer newdbtx.Rollback()
 
-	_, result, err := api.traceBlock(newdbtx, ctx, bNum, addr, chainConfig)
+	found, result, err := api.traceBlock(newdbtx, ctx, bNum, addr, chainConfig)
+	if !found {
+		// tx execution result and callFromToProvider() result mismatch
+		err = fmt.Errorf("search trace failure: inconsistency at block %d", bNum)
+		select {
+		case <-traceCtx.Done():
+			return 
+		case errCh <- err:
+		default:
+		}
+		traceCtxCancel()
+		return 
+	}
 	if err != nil {
 		log.Error("Search trace error", "err", err)
 		results[idx] = nil


### PR DESCRIPTION
-  Add `l1costfunc` logic for ots api: To avoid panic which leads server down
-  Add fallback logic when `senders` is null: To avoid API error for prebedrock blocks.
-  Error handle block tracing when db inconsistency detected: To avoid tracing every bedrock block for SequencerFeeVault(`0x42...011`). Db inconsistency must be eventually fixed.