### PR TITLE
Fix cbor decoding for receipt

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -20,10 +20,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/holiman/uint256"
-	"github.com/ledgerwatch/erigon-lib/chain"
 	"io"
 	"math/big"
+
+	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/erigon-lib/chain"
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 
@@ -65,10 +66,6 @@ type Receipt struct {
 	ContractAddress libcommon.Address `json:"contractAddress" codec:"-"`
 	GasUsed         uint64            `json:"gasUsed" gencodec:"required" codec:"-"`
 
-	// DepositNonce was introduced in Regolith to store the actual nonce used by deposit transactions
-	// The state transition process ensures this is only set for Regolith deposit transactions.
-	DepositNonce *uint64 `json:"depositNonce,omitempty"`
-
 	// Inclusion information: These fields provide information about the inclusion of the
 	// transaction corresponding to this receipt.
 	BlockHash        libcommon.Hash `json:"blockHash,omitempty" codec:"-"`
@@ -80,6 +77,13 @@ type Receipt struct {
 	L1GasUsed  *big.Int   `json:"l1GasUsed,omitempty"`
 	L1Fee      *big.Int   `json:"l1Fee,omitempty"`
 	FeeScalar  *big.Float `json:"l1FeeScalar,omitempty"`
+
+	// DepositNonce was introduced in Regolith to store the actual nonce used by deposit transactions
+	// The state transition process ensures this is only set for Regolith deposit transactions.
+	DepositNonce *uint64 `json:"depositNonce,omitempty"`
+	// The position of DepositNonce variable must NOT be changed. If changed, cbor decoding will fail
+
+	// Further fields when added must be appended after the last variable. Watch out for cbor!
 }
 
 type receiptMarshaling struct {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -82,8 +82,9 @@ type Receipt struct {
 	// The state transition process ensures this is only set for Regolith deposit transactions.
 	DepositNonce *uint64 `json:"depositNonce,omitempty"`
 	// The position of DepositNonce variable must NOT be changed. If changed, cbor decoding will fail
+	// for the data following previous struct and leading to decoding error(triggering backward imcompatibility).
 
-	// Further fields when added must be appended after the last variable. Watch out for cbor!
+	// Further fields when added must be appended after the last variable. Watch out for cbor.
 }
 
 type receiptMarshaling struct {

--- a/core/types/receipt_codecgen_gen.go
+++ b/core/types/receipt_codecgen_gen.go
@@ -64,11 +64,11 @@ func (x *Receipt) CodecEncodeSelf(e *codec1978.Encoder) {
 			yy2arr2 := z.EncBasicHandle().StructToArray
 			_ = yy2arr2
 			const yyr2 bool = false // struct tag has 'toArray'
-			var yyn7 bool = x.DepositNonce == nil
-			var yyn8 bool = x.L1GasPrice == nil
-			var yyn9 bool = x.L1GasUsed == nil
-			var yyn10 bool = x.L1Fee == nil
-			var yyn11 bool = x.FeeScalar == nil
+			var yyn7 bool = x.L1GasPrice == nil
+			var yyn8 bool = x.L1GasUsed == nil
+			var yyn9 bool = x.L1Fee == nil
+			var yyn10 bool = x.FeeScalar == nil
+			var yyn11 bool = x.DepositNonce == nil
 			z.EncWriteArrayStart(9)
 			z.EncWriteArrayElem()
 			r.EncodeUint(uint64(x.Type))
@@ -87,21 +87,13 @@ func (x *Receipt) CodecEncodeSelf(e *codec1978.Encoder) {
 				r.EncodeNil()
 			} else {
 				z.EncWriteArrayElem()
-				yy16 := *x.DepositNonce
-				r.EncodeUint(uint64(yy16))
-			}
-			if yyn8 {
-				z.EncWriteArrayElem()
-				r.EncodeNil()
-			} else {
-				z.EncWriteArrayElem()
 				if !z.EncBinary() && z.IsJSONHandle() {
 					z.EncJSONMarshal(x.L1GasPrice)
 				} else {
 					z.EncFallback(x.L1GasPrice)
 				}
 			}
-			if yyn9 {
+			if yyn8 {
 				z.EncWriteArrayElem()
 				r.EncodeNil()
 			} else {
@@ -112,7 +104,7 @@ func (x *Receipt) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(x.L1GasUsed)
 				}
 			}
-			if yyn10 {
+			if yyn9 {
 				z.EncWriteArrayElem()
 				r.EncodeNil()
 			} else {
@@ -123,7 +115,7 @@ func (x *Receipt) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(x.L1Fee)
 				}
 			}
-			if yyn11 {
+			if yyn10 {
 				z.EncWriteArrayElem()
 				r.EncodeNil()
 			} else {
@@ -133,6 +125,14 @@ func (x *Receipt) CodecEncodeSelf(e *codec1978.Encoder) {
 				} else {
 					z.EncFallback(x.FeeScalar)
 				}
+			}
+			if yyn11 {
+				z.EncWriteArrayElem()
+				r.EncodeNil()
+			} else {
+				z.EncWriteArrayElem()
+				yy20 := *x.DepositNonce
+				r.EncodeUint(uint64(yy20))
 			}
 			z.EncWriteArrayEnd()
 		}
@@ -195,17 +195,6 @@ func (x *Receipt) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			x.Status = (uint64)(r.DecodeUint64())
 		case "3":
 			x.CumulativeGasUsed = (uint64)(r.DecodeUint64())
-		case "DepositNonce":
-			if r.TryNil() {
-				if x.DepositNonce != nil { // remove the if-true
-					x.DepositNonce = nil
-				}
-			} else {
-				if x.DepositNonce == nil {
-					x.DepositNonce = new(uint64)
-				}
-				*x.DepositNonce = (uint64)(r.DecodeUint64())
-			}
 		case "L1GasPrice":
 			if r.TryNil() {
 				if x.L1GasPrice != nil { // remove the if-true
@@ -265,6 +254,17 @@ func (x *Receipt) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				} else {
 					z.DecFallback(x.FeeScalar, false)
 				}
+			}
+		case "DepositNonce":
+			if r.TryNil() {
+				if x.DepositNonce != nil { // remove the if-true
+					x.DepositNonce = nil
+				}
+			} else {
+				if x.DepositNonce == nil {
+					x.DepositNonce = new(uint64)
+				}
+				*x.DepositNonce = (uint64)(r.DecodeUint64())
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3)
@@ -327,27 +327,6 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecReadArrayElem()
 	x.CumulativeGasUsed = (uint64)(r.DecodeUint64())
-	yyj19++
-	if yyhl19 {
-		yyb19 = yyj19 > l
-	} else {
-		yyb19 = z.DecCheckBreak()
-	}
-	if yyb19 {
-		z.DecReadArrayEnd()
-		return
-	}
-	z.DecReadArrayElem()
-	if r.TryNil() {
-		if x.DepositNonce != nil { // remove the if-true
-			x.DepositNonce = nil
-		}
-	} else {
-		if x.DepositNonce == nil {
-			x.DepositNonce = new(uint64)
-		}
-		*x.DepositNonce = (uint64)(r.DecodeUint64())
-	}
 	yyj19++
 	if yyhl19 {
 		yyb19 = yyj19 > l
@@ -447,6 +426,27 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		} else {
 			z.DecFallback(x.FeeScalar, false)
 		}
+	}
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
+	} else {
+		yyb19 = z.DecCheckBreak()
+	}
+	if yyb19 {
+		z.DecReadArrayEnd()
+		return
+	}
+	z.DecReadArrayElem()
+	if r.TryNil() {
+		if x.DepositNonce != nil { // remove the if-true
+			x.DepositNonce = nil
+		}
+	} else {
+		if x.DepositNonce == nil {
+			x.DepositNonce = new(uint64)
+		}
+		*x.DepositNonce = (uint64)(r.DecodeUint64())
 	}
 	for {
 		yyj19++


### PR DESCRIPTION
This fix(~hack~) dodges below error.

```
EROR[03-20|14:24:11.673] receipt unmarshal failed                 err="cbor decode error [pos 9]: invalid integer c1 (tag); got major 6, expected 0 or 1"
```

This error only occurred for prebedrock. db stored prebedrock receipt data does not know application logic has changed(`DepositNonce` added). Our application code tries to decode by using newly updated cbor. cbor parses fields sequentially. Therefore if new field is added, it must be appended to last field element. More precisely, newly added field must not break previous cbor decoding symantic. This is the key for backward compatibility. 

