### PR TITLE
Unwind mining stages for self reorg

### DIFF
--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -384,5 +384,9 @@ var DefaultPruneOrder = PruneOrder{
 	stages.Headers,
 }
 
-var MiningUnwindOrder = UnwindOrder{} // nothing to unwind in mining - because mining does not commit db changes
-var MiningPruneOrder = PruneOrder{}   // nothing to unwind in mining - because mining does not commit db changes
+var MiningUnwindOrder = UnwindOrder{
+	stages.HashState,
+	stages.IntermediateHashes,
+	stages.MiningExecution,
+}
+var MiningPruneOrder = PruneOrder{} // nothing to unwind in mining - because mining does not commit db changes

--- a/eth/stagedsync/stage_mining_create_block.go
+++ b/eth/stagedsync/stage_mining_create_block.go
@@ -122,22 +122,20 @@ func SpawnMiningCreateBlockStage(s *StageState, tx kv.RwTx, cfg MiningCreateBloc
 			if err != nil {
 				return err
 			}
-			executionAt = exectedParent.Number.Uint64()
+			expectedExecutionAt := exectedParent.Number.Uint64()
+			hashStateProgress, err := stages.GetStageProgress(tx, stages.HashState)
+			if err != nil {
+				return err
+			}
+			if hashStateProgress > expectedExecutionAt {
+				if err = stages.SaveStageProgress(tx, stages.MiningExecution, executionAt); err != nil {
+					return err
+				}
+				s.state.UnwindTo(expectedExecutionAt, libcommon.Hash{})
+				return nil
+			}
+			executionAt = expectedExecutionAt
 			parent = exectedParent
-
-			if err = stages.SaveStageProgress(tx, stages.MiningCreateBlock, executionAt); err != nil {
-				return err
-			}
-			if err = stages.SaveStageProgress(tx, stages.MiningExecution, executionAt); err != nil {
-				return err
-			}
-			if err = stages.SaveStageProgress(tx, stages.HashState, executionAt); err != nil {
-				return err
-			}
-			if err = stages.SaveStageProgress(tx, stages.IntermediateHashes, executionAt); err != nil {
-				return err
-			}
-			log.Info("updated executionAt", "executionAt", executionAt)
 		} else {
 			return fmt.Errorf("wrong head block: %x (current) vs %x (requested)", parent.Hash(), cfg.blockBuilderParameters.ParentHash)
 		}

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -622,32 +622,5 @@ func unwindMiningExecutionStage(u *UnwindState, s *StageState, tx kv.RwTx, ctx c
 		return err
 	}
 
-	//if err := rawdb.TruncateReceipts(tx, u.UnwindPoint+1); err != nil {
-	//	return fmt.Errorf("truncate receipts: %w", err)
-	//}
-	//if err := rawdb.TruncateBorReceipts(tx, u.UnwindPoint+1); err != nil {
-	//	return fmt.Errorf("truncate bor receipts: %w", err)
-	//}
-	//if err := rawdb.DeleteNewerEpochs(tx, u.UnwindPoint+1); err != nil {
-	//	return fmt.Errorf("delete newer epochs: %w", err)
-	//}
-	//
-	//// Truncate CallTraceSet
-	//keyStart := hexutility.EncodeTs(u.UnwindPoint + 1)
-	//c, err := tx.RwCursorDupSort(kv.CallTraceSet)
-	//if err != nil {
-	//	return err
-	//}
-	//defer c.Close()
-	//for k, _, err := c.Seek(keyStart); k != nil; k, _, err = c.NextNoDup() {
-	//	if err != nil {
-	//		return err
-	//	}
-	//	err = c.DeleteCurrentDuplicates()
-	//	if err != nil {
-	//		return err
-	//	}
-	//}
-
 	return nil
 }

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -4,6 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/ledgerwatch/erigon-lib/common/length"
+	"github.com/ledgerwatch/erigon-lib/etl"
+	"github.com/ledgerwatch/erigon-lib/kv/temporal/historyv2"
+	"github.com/ledgerwatch/erigon/common/changeset"
+	"github.com/ledgerwatch/erigon/common/dbutils"
 	"io"
 	"math/big"
 	"sync/atomic"
@@ -95,7 +100,7 @@ func SpawnMiningExecStage(s *StageState, tx kv.RwTx, cfg MiningExecCfg, quit <-c
 	forceTxs := current.ForceTxs
 	noempty := true
 
-	stateReader := state.NewPlainState(tx, current.Header.Number.Uint64(), systemcontracts.SystemContractCodeLookup[cfg.chainConfig.ChainName])
+	stateReader := state.NewPlainStateReader(tx)
 	ibs := state.New(stateReader)
 	stateWriter := state.NewPlainStateWriter(tx, tx, current.Header.Number.Uint64())
 	if cfg.chainConfig.DAOForkSupport && cfg.chainConfig.DAOForkBlock != nil && cfg.chainConfig.DAOForkBlock.Cmp(current.Header.Number) == 0 {
@@ -514,4 +519,135 @@ func NotifyPendingLogs(logPrefix string, notifier ChainEventNotifier, logs types
 		return
 	}
 	notifier.OnNewPendingLogs(logs)
+}
+
+func UnwindMiningExecutionStage(u *UnwindState, s *StageState, tx kv.RwTx, ctx context.Context, cfg MiningExecCfg) (err error) {
+	if u.UnwindPoint >= s.BlockNumber {
+		return nil
+	}
+	useExternalTx := tx != nil
+	if !useExternalTx {
+		tx, err = cfg.db.BeginRw(context.Background())
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+	}
+	logPrefix := u.LogPrefix()
+	log.Info(fmt.Sprintf("[%s] Unwind Mining Execution", logPrefix), "from", s.BlockNumber, "to", u.UnwindPoint)
+
+	if err = unwindMiningExecutionStage(u, s, tx, ctx, cfg); err != nil {
+		return err
+	}
+	if err = u.Done(tx); err != nil {
+		return err
+	}
+
+	if !useExternalTx {
+		if err = tx.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func unwindMiningExecutionStage(u *UnwindState, s *StageState, tx kv.RwTx, ctx context.Context, cfg MiningExecCfg) error {
+	logPrefix := s.LogPrefix()
+	stateBucket := kv.PlainState
+	storageKeyLength := length.Addr + length.Incarnation + length.Hash
+
+	changes := etl.NewCollector(logPrefix, cfg.tmpdir, etl.NewOldestEntryBuffer(etl.BufferOptimalSize))
+	defer changes.Close()
+	errRewind := changeset.RewindData(tx, s.BlockNumber, u.UnwindPoint, changes, ctx.Done())
+	if errRewind != nil {
+		return fmt.Errorf("getting rewind data: %w", errRewind)
+	}
+
+	if err := changes.Load(tx, stateBucket, func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
+		if len(k) == 20 {
+			if len(v) > 0 {
+				var acc accounts.Account
+				if err := acc.DecodeForStorage(v); err != nil {
+					return err
+				}
+
+				// Fetch the code hash
+				recoverCodeHashPlain(&acc, tx, k)
+				var address libcommon.Address
+				copy(address[:], k)
+
+				// cleanup contract code bucket
+				original, err := state.NewPlainStateReader(tx).ReadAccountData(address)
+				if err != nil {
+					return fmt.Errorf("read account for %x: %w", address, err)
+				}
+				if original != nil {
+					// clean up all the code incarnations original incarnation and the new one
+					for incarnation := original.Incarnation; incarnation > acc.Incarnation && incarnation > 0; incarnation-- {
+						err = tx.Delete(kv.PlainContractCode, dbutils.PlainGenerateStoragePrefix(address[:], incarnation))
+						if err != nil {
+							return fmt.Errorf("writeAccountPlain for %x: %w", address, err)
+						}
+					}
+				}
+
+				newV := make([]byte, acc.EncodingLengthForStorage())
+				acc.EncodeForStorage(newV)
+				if err := next(k, k, newV); err != nil {
+					return err
+				}
+			} else {
+				if err := next(k, k, nil); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		if len(v) > 0 {
+			if err := next(k, k[:storageKeyLength], v); err != nil {
+				return err
+			}
+		} else {
+			if err := next(k, k[:storageKeyLength], nil); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	}, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+		return err
+	}
+
+	if err := historyv2.Truncate(tx, u.UnwindPoint+1); err != nil {
+		return err
+	}
+
+	//if err := rawdb.TruncateReceipts(tx, u.UnwindPoint+1); err != nil {
+	//	return fmt.Errorf("truncate receipts: %w", err)
+	//}
+	//if err := rawdb.TruncateBorReceipts(tx, u.UnwindPoint+1); err != nil {
+	//	return fmt.Errorf("truncate bor receipts: %w", err)
+	//}
+	//if err := rawdb.DeleteNewerEpochs(tx, u.UnwindPoint+1); err != nil {
+	//	return fmt.Errorf("delete newer epochs: %w", err)
+	//}
+	//
+	//// Truncate CallTraceSet
+	//keyStart := hexutility.EncodeTs(u.UnwindPoint + 1)
+	//c, err := tx.RwCursorDupSort(kv.CallTraceSet)
+	//if err != nil {
+	//	return err
+	//}
+	//defer c.Close()
+	//for k, _, err := c.Seek(keyStart); k != nil; k, _, err = c.NextNoDup() {
+	//	if err != nil {
+	//		return err
+	//	}
+	//	err = c.DeleteCurrentDuplicates()
+	//	if err != nil {
+	//		return err
+	//	}
+	//}
+
+	return nil
 }

--- a/eth/stagedsync/stagebuilder.go
+++ b/eth/stagedsync/stagebuilder.go
@@ -49,8 +49,10 @@ func MiningStages(
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *StageState, u Unwinder, tx kv.RwTx, quiet bool) error {
 				return SpawnMiningExecStage(s, tx, execCfg, ctx.Done())
 			},
-			Unwind: func(firstCycle bool, u *UnwindState, s *StageState, tx kv.RwTx) error { return nil },
-			Prune:  func(firstCycle bool, u *PruneState, tx kv.RwTx) error { return nil },
+			Unwind: func(firstCycle bool, u *UnwindState, s *StageState, tx kv.RwTx) error {
+				return UnwindMiningExecutionStage(u, s, tx, ctx, execCfg)
+			},
+			Prune: func(firstCycle bool, u *PruneState, tx kv.RwTx) error { return nil },
 		},
 		{
 			ID:          stages.HashState,
@@ -58,8 +60,10 @@ func MiningStages(
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *StageState, u Unwinder, tx kv.RwTx, quiet bool) error {
 				return SpawnHashStateStage(s, tx, hashStateCfg, ctx, quiet)
 			},
-			Unwind: func(firstCycle bool, u *UnwindState, s *StageState, tx kv.RwTx) error { return nil },
-			Prune:  func(firstCycle bool, u *PruneState, tx kv.RwTx) error { return nil },
+			Unwind: func(firstCycle bool, u *UnwindState, s *StageState, tx kv.RwTx) error {
+				return UnwindHashStateStage(u, s, tx, hashStateCfg, ctx)
+			},
+			Prune: func(firstCycle bool, u *PruneState, tx kv.RwTx) error { return nil },
 		},
 		{
 			ID:          stages.IntermediateHashes,
@@ -72,8 +76,10 @@ func MiningStages(
 				createBlockCfg.miner.MiningBlock.Header.Root = stateRoot
 				return nil
 			},
-			Unwind: func(firstCycle bool, u *UnwindState, s *StageState, tx kv.RwTx) error { return nil },
-			Prune:  func(firstCycle bool, u *PruneState, tx kv.RwTx) error { return nil },
+			Unwind: func(firstCycle bool, u *UnwindState, s *StageState, tx kv.RwTx) error {
+				return UnwindIntermediateHashesStage(u, s, tx, trieCfg, ctx)
+			},
+			Prune: func(firstCycle bool, u *PruneState, tx kv.RwTx) error { return nil },
 		},
 		{
 			ID:          stages.MiningFinish,


### PR DESCRIPTION
The previous stupid PR for L2 Reorg handling is not working.

To build a payload with reorg, we have to unwind state changes to the target reorg block before running mining stages.

Stages we need to unwind are `HashState`, `InterMediateHashses`, `MiningExecution` - all related to state trie, change sets, and trie root hash calculation.

We don't have to consider any other tables like receipts, index, etc. Because mining stages does not commit anything to DB, and those things will be unwinded when we apply the new payload.

FYI, New unwind method of `MiningExecution` is copied from `Execution` stage, and removed some unnecessary code 