### PR TITLE
Return true in GetSender() of depositTx

### DIFF
--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -83,7 +83,7 @@ func (tx DepositTx) GetData() []byte {
 }
 
 func (tx DepositTx) GetSender() (libcommon.Address, bool) {
-	return tx.From, false
+	return tx.From, true
 }
 
 func (tx DepositTx) SetSender(addr libcommon.Address) {


### PR DESCRIPTION
DepositTx's GetSender() method always returns false, so the contractAddress of receipt is not derived.