### PR TITLE
Ignore L1Cost for fake messages

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -802,6 +802,7 @@ func (m callMsg) Value() *uint256.Int                { return m.CallMsg.Value }
 func (m callMsg) Data() []byte                       { return m.CallMsg.Data }
 func (m callMsg) AccessList() types2.AccessList      { return m.CallMsg.AccessList }
 func (m callMsg) IsFree() bool                       { return false }
+func (m callMsg) IsFake() bool                       { return true }
 func (m callMsg) Mint() *uint256.Int                 { return nil }
 func (m callMsg) RollupDataGas() types.RollupGasData { return types.RollupGasData{} }
 func (m callMsg) IsDepositTx() bool                  { return false }

--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -214,7 +214,7 @@ func (args *TraceCallParam) ToMessage(globalGasCap uint64, baseFee *uint256.Int)
 	if args.AccessList != nil {
 		accessList = *args.AccessList
 	}
-	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, false /* checkNonce */, false /* isFree */, true)
+	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, false /* checkNonce */, false /* isFree */, true /* isFake */))
 	return msg, nil
 }
 

--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -214,7 +214,7 @@ func (args *TraceCallParam) ToMessage(globalGasCap uint64, baseFee *uint256.Int)
 	if args.AccessList != nil {
 		accessList = *args.AccessList
 	}
-	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, false /* checkNonce */, false /* isFree */)
+	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, false /* checkNonce */, false /* isFree */, true)
 	return msg, nil
 }
 

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1262,8 +1262,8 @@ func (p *Parlia) systemCall(from, contract libcommon.Address, data []byte, ibs *
 		math.MaxUint64/2, u256.Num0,
 		nil, nil,
 		data, nil, false,
-		true, // isFree
-		false,
+		true,  // isFree
+		false, // isFake
 	)
 	vmConfig := vm.Config{NoReceipts: true}
 	// Create a new context to be used in the EVM environment

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1263,6 +1263,7 @@ func (p *Parlia) systemCall(from, contract libcommon.Address, data []byte, ibs *
 		nil, nil,
 		data, nil, false,
 		true, // isFree
+		false,
 	)
 	vmConfig := vm.Config{NoReceipts: true}
 	// Create a new context to be used in the EVM environment

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -479,8 +479,8 @@ func SysCallContract(contract libcommon.Address, data []byte, chainConfig chain.
 		math.MaxUint64, u256.Num0,
 		nil, nil,
 		data, nil, false,
-		true, // isFree
-		false,
+		true,  // isFree
+		false, // isFake
 	)
 	vmConfig := vm.Config{NoReceipts: true, RestoreState: constCall}
 	// Create a new context to be used in the EVM environment
@@ -524,8 +524,8 @@ func SysCreate(contract libcommon.Address, data []byte, chainConfig chain.Config
 		math.MaxUint64, u256.Num0,
 		nil, nil,
 		data, nil, false,
-		true, // isFree
-		false,
+		true,  // isFree
+		false, // isFake
 	)
 	vmConfig := vm.Config{NoReceipts: true}
 	// Create a new context to be used in the EVM environment

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -480,6 +480,7 @@ func SysCallContract(contract libcommon.Address, data []byte, chainConfig chain.
 		nil, nil,
 		data, nil, false,
 		true, // isFree
+		false,
 	)
 	vmConfig := vm.Config{NoReceipts: true, RestoreState: constCall}
 	// Create a new context to be used in the EVM environment
@@ -524,6 +525,7 @@ func SysCreate(contract libcommon.Address, data []byte, chainConfig chain.Config
 		nil, nil,
 		data, nil, false,
 		true, // isFree
+		false,
 	)
 	vmConfig := vm.Config{NoReceipts: true}
 	// Create a new context to be used in the EVM environment

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -22,7 +22,6 @@ import (
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/txpool"
 	types2 "github.com/ledgerwatch/erigon-lib/types"
-
 	"github.com/ledgerwatch/erigon/common"
 	cmath "github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/common/u256"
@@ -99,6 +98,7 @@ type Message interface {
 	AccessList() types2.AccessList
 
 	IsFree() bool
+	IsFake() bool
 }
 
 // ExecutionResult includes all output after executing given evm
@@ -207,7 +207,7 @@ func (st *StateTransition) buyGas(gasBailout bool) error {
 		return fmt.Errorf("%w: address %v", ErrInsufficientFunds, st.msg.From().Hex())
 	}
 	var l1Cost *uint256.Int
-	if fn := st.evm.Context().L1CostFunc; fn != nil {
+	if fn := st.evm.Context().L1CostFunc; fn != nil && !st.msg.IsFake() {
 		l1Cost = fn(st.evm.Context().BlockNumber, st.evm.Context().Time, st.msg)
 	}
 	if l1Cost != nil {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -517,6 +517,7 @@ type Message struct {
 	accessList types2.AccessList
 	checkNonce bool
 	isFree     bool
+	isFake     bool
 
 	isSystemTx  bool
 	isDepositTx bool
@@ -524,7 +525,7 @@ type Message struct {
 	l1CostGas   RollupGasData
 }
 
-func NewMessage(from libcommon.Address, to *libcommon.Address, nonce uint64, amount *uint256.Int, gasLimit uint64, gasPrice *uint256.Int, feeCap, tip *uint256.Int, data []byte, accessList types2.AccessList, checkNonce bool, isFree bool) Message {
+func NewMessage(from libcommon.Address, to *libcommon.Address, nonce uint64, amount *uint256.Int, gasLimit uint64, gasPrice *uint256.Int, feeCap, tip *uint256.Int, data []byte, accessList types2.AccessList, checkNonce bool, isFree bool, isFake bool) Message {
 	m := Message{
 		from:       from,
 		to:         to,
@@ -535,6 +536,7 @@ func NewMessage(from libcommon.Address, to *libcommon.Address, nonce uint64, amo
 		accessList: accessList,
 		checkNonce: checkNonce,
 		isFree:     isFree,
+		isFake:     isFake,
 	}
 	if gasPrice != nil {
 		m.gasPrice.Set(gasPrice)
@@ -566,6 +568,7 @@ func (m Message) IsFree() bool { return m.isFree }
 func (m *Message) SetIsFree(isFree bool) {
 	m.isFree = isFree
 }
+func (m Message) IsFake() bool { return m.isFake }
 
 func (m *Message) ChangeGas(globalGasCap, desiredGas uint64) {
 	gas := globalGasCap

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -468,7 +468,7 @@ func toMessage(tx stTransactionMarshaling, ps stPostState, baseFee *big.Int) (co
 		accessList,
 		false, /* checkNonce */
 		false, /* isFree */
-		false,
+		false, /* isFake */
 	)
 
 	return msg, nil

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -467,7 +467,9 @@ func toMessage(tx stTransactionMarshaling, ps stPostState, baseFee *big.Int) (co
 		data,
 		accessList,
 		false, /* checkNonce */
-		false /* isFree */)
+		false, /* isFree */
+		false,
+	)
 
 	return msg, nil
 }

--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -145,7 +145,7 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *uint256.Int) (type
 		accessList = *args.AccessList
 	}
 
-	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, false /* checkNonce */, false /* isFree */, true)
+	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, false /* checkNonce */, false /* isFree */, true /* isFake */)
 	return msg, nil
 }
 

--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -145,7 +145,7 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *uint256.Int) (type
 		accessList = *args.AccessList
 	}
 
-	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, false /* checkNonce */, false /* isFree */)
+	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, false /* checkNonce */, false /* isFree */, true)
 	return msg, nil
 }
 


### PR DESCRIPTION
Simulated EVM executions like `eth_estimateGas` should not apply L1Cost.
To implement this, I bring the `isFake` property of `Message` from geth implementation.