### PR TITLE
Case handle depositNonce for optimism 

### DIFF
--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -312,6 +312,7 @@ func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, b
 		txs := block.Transactions()
 		transactions := make([]interface{}, len(txs), len(txs)+1)
 		if depositNonces == nil {
+			// ensure that depositNonces is always initialized for formatTx
 			depositNonces = make([]*uint64, len(txs))
 		}
 		var err error


### PR DESCRIPTION
Adds `isOptimism` check for `ReadDepositNonces` when necessary.
When result of `ReadDepositNonces` is not accessed by index but directly transferred to `RPCMarshalBlockEx`, error handling when `depositNonces` is null is taken inside the logic itself.