### PR TITLE
Relay Call Trace API

### DIFF
--- a/cmd/rpcdaemon/commands/debug_api.go
+++ b/cmd/rpcdaemon/commands/debug_api.go
@@ -54,6 +54,10 @@ func NewPrivateDebugAPI(base *BaseAPI, db kv.RoDB, gascap uint64) *PrivateDebugA
 	}
 }
 
+func (api *PrivateDebugAPIImpl) relayToHistoricalBackend(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	return api.historicalRPCService.CallContext(ctx, result, method, args...)
+}
+
 // storageRangeAt implements debug_storageRangeAt. Returns information about a range of storage locations (if any) for the given address.
 func (api *PrivateDebugAPIImpl) StorageRangeAt(ctx context.Context, blockHash common.Hash, txIndex uint64, contractAddress common.Address, keyStart hexutil.Bytes, maxResult int) (StorageRangeResult, error) {
 	tx, err := api.db.BeginRo(ctx)

--- a/cmd/rpcdaemon/commands/otterscan_api.go
+++ b/cmd/rpcdaemon/commands/otterscan_api.go
@@ -225,6 +225,8 @@ func (api *OtterscanAPIImpl) translateRelayTraceResult(gethTrace *GethTrace, tra
 	}
 	callStacks := make([]*traceWithIndex, 0)
 	started := false
+	// Each call stack can call and trigger sub call stack.
+	// rootIndex indicates the index of child for current inspected parent node trace.
 	rootIndex := 0
 	var trace *GethTrace = gethTrace
 	// iterative postorder traversal
@@ -256,6 +258,7 @@ func (api *OtterscanAPIImpl) translateRelayTraceResult(gethTrace *GethTrace, tra
 		if err := api.translateCaptureExit(top.gethTrace, tracer); err != nil {
 			return err
 		}
+		// pop back callstack repeatly until popped element is last children of top of the callstack
 		for len(callStacks) > 0 && top.idx == len(callStacks[len(callStacks)-1].gethTrace.Calls)-1 {
 			// pop back
 			top = callStacks[len(callStacks)-1]

--- a/cmd/rpcdaemon/commands/otterscan_api.go
+++ b/cmd/rpcdaemon/commands/otterscan_api.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv/order"
 	"github.com/ledgerwatch/erigon-lib/kv/rawdbv3"
 	"github.com/ledgerwatch/erigon/core/state/temporal"
+	"github.com/ledgerwatch/erigon/core/vm/evmtypes"
+	"github.com/ledgerwatch/erigon/eth/tracers"
 	"github.com/ledgerwatch/log/v3"
 
 	"github.com/ledgerwatch/erigon/common/hexutil"
@@ -112,6 +114,163 @@ func (api *OtterscanAPIImpl) getTransactionByHash(ctx context.Context, tx kv.Tx,
 	return txn, block, blockHash, blockNum, txnIndex, nil
 }
 
+func (api *OtterscanAPIImpl) relayToHistoricalBackend(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	return api.historicalRPCService.CallContext(ctx, result, method, args...)
+}
+
+func (api *OtterscanAPIImpl) translateCaptureStart(gethTrace *GethTrace, tracer vm.EVMLogger) error {
+	from := common.HexToAddress(gethTrace.From)
+	to := common.HexToAddress(gethTrace.To)
+	input, err := hexutil.Decode(gethTrace.Input)
+	if err != nil {
+		if err != hexutil.ErrEmptyString {
+			return err
+		}
+		input = []byte{}
+	}
+	valueBig, err := hexutil.DecodeBig(gethTrace.Value)
+	if err != nil {
+		if err != hexutil.ErrEmptyString {
+			return err
+		}
+		valueBig = big.NewInt(0)
+	}
+	value, _ := uint256.FromBig(valueBig)
+	gas, err := hexutil.DecodeUint64(gethTrace.Gas)
+	if err != nil {
+		return err
+	}
+	// dummy vmenv
+	vmenv := vm.NewEVM(evmtypes.BlockContext{}, evmtypes.TxContext{}, nil, &chain.Config{}, vm.Config{})
+	// dummy code
+	code := []byte{}
+	tracer.CaptureStart(vmenv, from, to, false, false, input, gas, value, code)
+	return nil
+}
+
+func (api *OtterscanAPIImpl) translateOpcode(typStr string) (vm.OpCode, error) {
+	switch typStr {
+	default:
+	case "CALL":
+		return vm.CALL, nil
+	case "STATICCALL":
+		return vm.STATICCALL, nil
+	case "DELEGATECALL":
+		return vm.DELEGATECALL, nil
+	case "CALLCODE":
+		return vm.CALLCODE, nil
+	case "CREATE":
+		return vm.CREATE, nil
+	case "CREATE2":
+		return vm.CREATE2, nil
+	case "SELFDESTRUCT":
+		return vm.SELFDESTRUCT, nil
+	}
+	return vm.INVALID, fmt.Errorf("unable to translate %s", typStr)
+}
+
+func (api *OtterscanAPIImpl) translateCaptureEnter(gethTrace *GethTrace, tracer vm.EVMLogger) error {
+	from := common.HexToAddress(gethTrace.From)
+	to := common.HexToAddress(gethTrace.To)
+	input, err := hexutil.Decode(gethTrace.Input)
+	if err != nil {
+		if err != hexutil.ErrEmptyString {
+			return err
+		}
+		input = []byte{}
+	}
+	valueBig, err := hexutil.DecodeBig(gethTrace.Value)
+	if err != nil {
+		if err != hexutil.ErrEmptyString {
+			return err
+		}
+		valueBig = big.NewInt(0)
+	}
+	value, _ := uint256.FromBig(valueBig)
+	gas, err := hexutil.DecodeUint64(gethTrace.Gas)
+	if err != nil {
+		return err
+	}
+	typStr := gethTrace.Type
+	typ, err := api.translateOpcode(typStr)
+	if err != nil {
+		return err
+	}
+	tracer.CaptureEnter(typ, from, to, false, false, input, gas, value, nil)
+	return nil
+}
+
+func (api *OtterscanAPIImpl) translateCaptureExit(gethTrace *GethTrace, tracer vm.EVMLogger) error {
+	usedGas, err := hexutil.DecodeUint64(gethTrace.GasUsed)
+	if err != nil {
+		return err
+	}
+	output, err := hexutil.Decode(gethTrace.Output)
+	if err != nil {
+		if err != hexutil.ErrEmptyString {
+			return err
+		}
+		output = []byte{}
+	}
+	err = errors.New(gethTrace.Error)
+	tracer.CaptureExit(output, usedGas, err)
+	return nil
+}
+
+func (api *OtterscanAPIImpl) translateRelayTraceResult(gethTrace *GethTrace, tracer vm.EVMLogger) error {
+	type traceWithIndex struct {
+		gethTrace *GethTrace
+		idx       int // children index
+	}
+	callStacks := make([]*traceWithIndex, 0)
+	started := false
+	rootIndex := 0
+	var trace *GethTrace = gethTrace
+	// iterative postorder traversal
+	for trace != nil || len(callStacks) > 0 {
+		if trace != nil {
+			// push back
+			callStacks = append(callStacks, &traceWithIndex{trace, rootIndex})
+			if !started {
+				started = true
+				if err := api.translateCaptureStart(trace, tracer); err != nil {
+					return err
+				}
+			} else {
+				if err := api.translateCaptureEnter(trace, tracer); err != nil {
+					return err
+				}
+			}
+			rootIndex = 0
+			if len(trace.Calls) > 0 {
+				trace = trace.Calls[0]
+			} else {
+				trace = nil
+			}
+			continue
+		}
+		// pop back
+		top := callStacks[len(callStacks)-1]
+		callStacks = callStacks[:len(callStacks)-1]
+		if err := api.translateCaptureExit(top.gethTrace, tracer); err != nil {
+			return err
+		}
+		for len(callStacks) > 0 && top.idx == len(callStacks[len(callStacks)-1].gethTrace.Calls)-1 {
+			// pop back
+			top = callStacks[len(callStacks)-1]
+			callStacks = callStacks[:len(callStacks)-1]
+			if err := api.translateCaptureExit(top.gethTrace, tracer); err != nil {
+				return err
+			}
+		}
+		if len(callStacks) > 0 {
+			trace = callStacks[len(callStacks)-1].gethTrace.Calls[top.idx+1]
+			rootIndex = top.idx + 1
+		}
+	}
+	return nil
+}
+
 func (api *OtterscanAPIImpl) runTracer(ctx context.Context, tx kv.Tx, hash common.Hash, tracer vm.EVMLogger) (*core.ExecutionResult, error) {
 	txn, block, _, _, txIndex, err := api.getTransactionByHash(ctx, tx, hash)
 	if err != nil {
@@ -125,6 +284,43 @@ func (api *OtterscanAPIImpl) runTracer(ctx context.Context, tx kv.Tx, hash commo
 	if err != nil {
 		return nil, err
 	}
+
+	blockNum := block.NumberU64()
+	if chainConfig.IsOptimismPreBedrock(blockNum) {
+		if api.historicalRPCService == nil {
+			return nil, rpc.ErrNoHistoricalFallback
+		}
+		// geth returns nested json so we have to flatten
+		treeResult := &GethTrace{}
+		callTracer := "callTracer"
+		if err := api.relayToHistoricalBackend(ctx, treeResult, "debug_traceTransaction", hash, &tracers.TraceConfig{Tracer: &callTracer}); err != nil {
+			return nil, fmt.Errorf("historical backend error: %w", err)
+		}
+		if tracer != nil {
+			err := api.translateRelayTraceResult(treeResult, tracer)
+			if err != nil {
+				return nil, err
+			}
+		}
+		usedGas, err := hexutil.DecodeUint64(treeResult.GasUsed)
+		if err != nil {
+			return nil, err
+		}
+		returnData, err := hexutil.Decode(treeResult.Output)
+		if err != nil {
+			if err != hexutil.ErrEmptyString {
+				return nil, err
+			}
+			returnData = []byte{}
+		}
+		result := &core.ExecutionResult{
+			UsedGas:    usedGas,
+			Err:        errors.New(treeResult.Error),
+			ReturnData: returnData,
+		}
+		return result, nil
+	}
+
 	engine := api.engine()
 
 	msg, blockCtx, txCtx, ibs, _, err := transactions.ComputeTxEnv(ctx, engine, block, chainConfig, api._blockReader, tx, int(txIndex), api.historyV3(tx))

--- a/cmd/rpcdaemon/commands/trace_types.go
+++ b/cmd/rpcdaemon/commands/trace_types.go
@@ -19,17 +19,17 @@ import (
 
 // GethTrace The trace as received from the existing Geth javascript tracer 'callTracer'
 type GethTrace struct {
-	Type    string     `json:"type"`
-	Error   string     `json:"error"`
-	From    string     `json:"from"`
-	To      string     `json:"to"`
-	Value   string     `json:"value"`
-	Gas     string     `json:"gas"`
-	GasUsed string     `json:"gasUsed"`
-	Input   string     `json:"input"`
-	Output  string     `json:"output"`
-	Time    string     `json:"time"`
-	Calls   GethTraces `json:"calls"`
+	Type    string     `json:"type,omitempty"`
+	Error   string     `json:"error,omitempty"`
+	From    string     `json:"from,omitempty"`
+	To      string     `json:"to,omitempty"`
+	Value   string     `json:"value,omitempty"`
+	Gas     string     `json:"gas,omitempty"`
+	GasUsed string     `json:"gasUsed,omitempty"`
+	Input   string     `json:"input,omitempty"`
+	Output  string     `json:"output,omitempty"`
+	Time    string     `json:"time,omitempty"`
+	Calls   GethTraces `json:"calls,omitempty"`
 }
 
 // GethTraces an array of GethTraces

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -58,6 +58,10 @@ func (evm *EVM) precompile(addr libcommon.Address) (PrecompiledContract, bool) {
 	return p, ok
 }
 
+func (evm *EVM) Precompile(addr libcommon.Address) (PrecompiledContract, bool) {
+	return evm.precompile(addr)
+}
+
 // run runs the given contract and takes care of running precompiles with a fallback to the byte code interpreter.
 func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, error) {
 	return evm.interpreter.Run(contract, input, readOnly)

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -8,9 +8,9 @@ import (
 // TraceConfig holds extra parameters to trace functions.
 type TraceConfig struct {
 	*logger.LogConfig
-	Tracer         *string
-	Timeout        *string
-	Reexec         *uint64
-	NoRefunds      *bool // Turns off gas refunds when tracing
-	StateOverrides *ethapi.StateOverrides
+	Tracer         *string                `json:"tracer"`
+	Timeout        *string                `json:"timeout,omitempty"`
+	Reexec         *uint64                `json:"reexec,omitempty"`
+	NoRefunds      *bool                  `json:"-"` // Turns off gas refunds when tracing
+	StateOverrides *ethapi.StateOverrides `json:"-"`
 }


### PR DESCRIPTION
This PR enables prebedrock relay for `debug_traceTransaction` and `ots_traceTransaction` related methods.

## `debug_traceTransaction`

Directly relay API response from l2geth. Stream out json response.

##  `ots_traceTransaction` related methods

Related methods: `ots_traceTransaction`, `ots_getTransactionError`, `ots_getInternalOperations` are all relayed. This is possible because I relayed `runTracer` method which is used by all otterscan tracing RPCs.

You may wonder l2geth does not have `ots_traceTransaction` implemented, and how could relaying be possible.

`ots_traceTransaction` can be _relayed_ by **rearranging** response from `debug_traceTransaction`.
For example, lets examine the following prebedrock tx with hash `txhash = 0xd2c3b3187d003fa65dcb991aba552f867d3b3e23ccfb6e87de15ed53ad819945`

API response from `debug_traceTransaction(txhash)`:
```json
{
        "jsonrpc": "2.0",
        "method": "debug_traceTransaction",
        "params": [
            "0xd2c3b3187d003fa65dcb991aba552f867d3b3e23ccfb6e87de15ed53ad819945",
             {"tracer": "callTracer"}
        ],
        "id": 2
}
```
Response:
```json
{
    "jsonrpc": "2.0",
    "result": {
        "calls": [
            {
                "from": "0x8c0fc35fca520134b1af215e80ce16762dc33629",
                "gas": "0x95cdb4",
                "gasUsed": "0x254b",
                "input": "0xa2fb6d6f00000000000000000000000000000000000000000000000000000000000003490000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000c4c6f735f416e67656c6573000000000000000000000000000000000000000000",
                "output": "0x00000000000000000000000000000000000000000000000001c0000000000aed",
                "to": "0xc894aede7c6f4e7c17bfb959b438704dc4339931",
                "type": "CALL",
                "value": "0x0"
            }
        ],
        "from": "0xad0470d15222810ad47f4cd977493ab5fee8258e",
        "gas": "0x98421c",
        "gasUsed": "0x3a50",
        "input": "0x661eec460000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b4c6f735f416e67656c6573000000000000000000000000000000000000000000",
        "output": "0x",
        "time": "23.999465ms",
        "to": "0x8c0fc35fca520134b1af215e80ce16762dc33629",
        "type": "CALL",
        "value": "0x0"
    },
    "id": 2
}
```

Desired output from `ots_traceTransaction(txhash)`:
```
{
    "jsonrpc": "2.0",
    "id": 6,
    "result": [
        {
            "type": "CALL",
            "depth": 0,
            "from": "0xad0470d15222810ad47f4cd977493ab5fee8258e",
            "to": "0x8c0fc35fca520134b1af215e80ce16762dc33629",
            "value": "0x0",
            "input": "0x661eec460000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b4c6f735f416e67656c6573000000000000000000000000000000000000000000"
        },
        {
            "type": "CALL",
            "depth": 1,
            "from": "0x8c0fc35fca520134b1af215e80ce16762dc33629",
            "to": "0xc894aede7c6f4e7c17bfb959b438704dc4339931",
            "value": "0x0",
            "input": "0xa2fb6d6f00000000000000000000000000000000000000000000000000000000000003490000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000c4c6f735f416e67656c6573000000000000000000000000000000000000000000"
        }
    ]
}
```

Therefore to generate response of `ots_traceTransaction`, we must do [iterative postorder traversal](https://www.geeksforgeeks.org/iterative-postorder-traversal-of-n-ary-tree) by parsing `debug_traceTransaction` result. I chose iterating not recursing to avoid stack memory consumption.

So,
1. Get trace result using `debug_traceTransaction(txhash)`
2. Flatten nested response in iterative postorder traversal manner.
3. While iterating, call methods for `vm.EVMLogger` for stacking up call traces. This automatically adds `depth` field to each call frames from l2geth.

