### PR TITLE
Fix Deposit Transaction Consensus Error

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -269,6 +269,12 @@ func (st *StateTransition) preCheck(gasBailout bool) error {
 		// Gas is free, but no refunds!
 		st.initialGas = st.msg.Gas()
 		st.gas += st.msg.Gas() // Add gas here in order to be able to execute calls.
+		// gas used by deposits may not be used by other txs
+		if err := st.gp.SubGas(st.msg.Gas()); err != nil {
+			if !gasBailout {
+				return err
+			}
+		}
 		// Don't touch the gas pool for system transactions
 		if st.msg.IsSystemTx() {
 			if st.evm.ChainConfig().IsOptimismRegolith(st.evm.Context().Time) {
@@ -277,7 +283,7 @@ func (st *StateTransition) preCheck(gasBailout bool) error {
 			}
 			return nil
 		}
-		return st.gp.SubGas(st.msg.Gas()) // gas used by deposits may not be used by other txs
+		return nil
 	}
 	// Make sure this transaction's nonce is correct.
 	if st.msg.CheckNonce() {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -279,12 +279,6 @@ func (st *StateTransition) preCheck(gasBailout bool) error {
 		// Gas is free, but no refunds!
 		st.initialGas = st.msg.Gas()
 		st.gas += st.msg.Gas() // Add gas here in order to be able to execute calls.
-		// gas used by deposits may not be used by other txs
-		if err := st.gp.SubGas(st.msg.Gas()); err != nil {
-			if !gasBailout {
-				return err
-			}
-		}
 		// Don't touch the gas pool for system transactions
 		if st.msg.IsSystemTx() {
 			if st.evm.ChainConfig().IsOptimismRegolith(st.evm.Context().Time) {
@@ -292,6 +286,12 @@ func (st *StateTransition) preCheck(gasBailout bool) error {
 					st.msg.From().Hex())
 			}
 			return nil
+		}
+		// gas used by deposits may not be used by other txs
+		if err := st.gp.SubGas(st.msg.Gas()); err != nil {
+			if !gasBailout {
+				return err
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
## Issue

Consensus broke when deposit transaction executed.
- Expected result: Consensus error related with insufficient funds(`tx.value > from.balance`)
- op-erigon's result: Internal VM error(`ErrInsufficientBalance`) 

FYI, two types of error will be returned when transaction is executed. [Ref](https://github.com/ethereum/go-ethereum/pull/20830)
- consensus error
- evm internal error
> The former should be converted to a consensus issue, e.g. The sender doesn't enough asset to purchase the gas it specifies. The latter is allowed since evm itself is a blackbox and internal error is allowed to happen.

## Consensus Error Implementation Divergence between [geth](https://github.com/ethereum/go-ethereum) and [erigon](https://github.com/ledgerwatch/erigon)

To be clear, I first explain implementations NOT related with optimism.

There are six rules(clauses) to satisfy consensus rules:
```
	// 1. the nonce of the message caller is correct
	// 2. caller has enough balance to cover transaction fee(gaslimit * gasprice)
	// 3. the amount of gas required is available in the block
	// 4. the purchased gas is enough to cover intrinsic usage
	// 5. there is no overflow when calculating intrinsic gas
	// 6. caller has enough balance to cover asset transfer for **topmost** call
```

For erigon, clauses 1-3 and 6 are checked at `StateTransition.preCheck` method.
For geth, clauses 1-3 are checked at `StateTransition.preCheck` method, and clause 6 is checked at `StateTransition.innerTransitionDb` method.

But when we compare the two different implementations of `preCheck` method between [geth](https://github.com/ethereum/go-ethereum/blob/b946b7a13b749c99979e312c83dce34cac8dd7b1/core/state_transition.go#L250) and [erigon](https://github.com/ledgerwatch/erigon/blob/3d904d509e806d19b0dd54c09ff12360cdd09504/core/state_transition.go#L251), they are semantically same. 

The diff was introduced at erigon's PR https://github.com/ledgerwatch/erigon/pull/2424: As the PR name says: `Remove unnecessary value transfer check from TransitionDb`, [geth's explicit clause 6](https://github.com/ethereum/go-ethereum/blob/b946b7a13b749c99979e312c83dce34cac8dd7b1/core/state_transition.go#L351-L354) checking is unnecessary.

It is because `preCheck` method in erigon and geth both checks that `tx.value + alpha <= from.balance` where `alpha` is a nonnegative scalar value resulted from gas fee logic, and geth's explicit clause 6 checks `tx.value <= from.balance`. So we do not have to double check. The actual inequality check is done by `StateTransaction.buyGas` method which is called by `preCheck` method.

## Deposit Transaction Handling for [op-geth](https://github.com/ethereum-optimism/op-geth)

op-geth introduces specific logic for deposit transaction in `preCheck` method. Here is the [diff](https://github.com/ethereum-optimism/op-geth/blob/c669d0271df7324d86a905fbd75fd48494572a2a/core/state_transition.go#L271-L284):
```go
	if st.msg.IsDepositTx() {
		// No fee fields to check, no nonce to check, and no need to check if EOA (L1 already verified it for us)
		// Gas is free, but no refunds!
		st.initialGas = st.msg.Gas()
		st.gas += st.msg.Gas() // Add gas here in order to be able to execute calls.
		// Don't touch the gas pool for system transactions
		if st.msg.IsSystemTx() {
			if st.evm.ChainConfig().IsOptimismRegolith(st.evm.Context.Time) {
				return fmt.Errorf("%w: address %v", ErrSystemTxNotSupported,
					st.msg.From().Hex())
			}
			return nil
		}
		return st.gp.SubGas(st.msg.Gas()) // gas used by deposits may not be used by other txs
	}
```

So if deposit transaction kicks in, `buyGas` method never executed, but it is okay because `innerTransitionDb` itself again checks clause 6. Double checking saved op-geth!

## Deposit Transaction Handling for op-erigon

We naively applied op-geth's diff, but did not took care of implementation divergence between erigon and geth. So we explicitly check clause 6 inside of `preCheck` method only for deposit transaction. This finally brings us consensus.

## Misc

Also added consistency in `preCheck` logic, considering `gasBailout` boolean. Refer to erigon's `buyGas` implementation.





















