### PR TITLE
Avoid nil Topics value for `eth_subscribe` log json response

### DIFF
--- a/cmd/rpcdaemon/commands/eth_filters.go
+++ b/cmd/rpcdaemon/commands/eth_filters.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/log/v3"
 
 	"github.com/ledgerwatch/erigon/common/debug"
@@ -260,6 +261,9 @@ func (api *APIImpl) Logs(ctx context.Context, crit filters.FilterCriteria) (*rpc
 			select {
 			case h, ok := <-logs:
 				if h != nil {
+					if h.Topics == nil {
+						h.Topics = []libcommon.Hash{}
+					}
 					err := notifier.Notify(rpcSub.ID, h)
 					if err != nil {
 						log.Warn("error while notifying subscription", "err", err)

--- a/cmd/rpcdaemon/commands/eth_filters.go
+++ b/cmd/rpcdaemon/commands/eth_filters.go
@@ -261,6 +261,7 @@ func (api *APIImpl) Logs(ctx context.Context, crit filters.FilterCriteria) (*rpc
 			select {
 			case h, ok := <-logs:
 				if h != nil {
+					// avoid null json array for topics
 					if h.Topics == nil {
 						h.Topics = []libcommon.Hash{}
 					}


### PR DESCRIPTION
According to the [go json doc](https://golang.org/pkg/encoding/json/#Marshal),
> Array and slice values encode as JSON arrays, except that []byte encodes as a base64-encoded string, and a nil slice encodes as the null JSON value.

When `Log` struct is created, `Topics []libcommon.Hash ` field may not be initialized when [anonymous event](https://docs.ethers.org/v5/concepts/events/#events-solidity) is emitted.
> For anonymous events, up to 4 topics may be indexed, and there is no signature topic hash, so the events cannot be filtered by the event signature.

So if no topics are indexed for anonymous events, `Log`'s `Topics` field will be empty. Erigon currently does not initialize and leaves  `Topics []libcommon.Hash ` field to be `nil`, leading json encoding to result in `null`. However if erigon tries to decode json which contains `Log`s which value is `null`, it will result in error. See [gen_log_json.go](https://github.com/testinprod-io/erigon/blob/03f737c4583f2470fcc7933d1b61b668d172230d/core/types/gen_log_json.go)'s `UnmarshalJSON` method.

https://github.com/testinprod-io/erigon/blob/03f737c4583f2470fcc7933d1b61b668d172230d/core/types/gen_log_json.go#L63-L66

`Log` can be accessed by two methods. The first one is fetching receipt by calling `eth_getTransactionReceipt`. While generating json response, the `marshalReceipt` method takes care of `nil` topic, and sets the value to empty array `[]`. 

Currently second method is a problem. We can fetch live `Log`s by using `eth_subscribe` websocket connection. Below is the part of implementation:
https://github.com/testinprod-io/erigon/blob/0bcc2bcc56665c072a76a0171cc84022e291c5bf/cmd/rpcdaemon/commands/eth_filters.go#L262-L263

It notifies by encoding `Log` struct as json. In this control flow, `nil` topics were not considered, leading `Log`'s `Topics` value to be `null`.

This PR avoids this by explicitly initializing `Topics` field when `Topics` field is not initialized.





















