### PR TITLE
Update and rename hive-nightly.yml to hive.yml

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -1,4 +1,4 @@
-name: Hive (Nightly)
+name: Hive
 
 on:
   push:


### PR DESCRIPTION
Nightly sometimes refers to unstable status. But the rationale behind hive-nightly was literally running this thing at night. 

We might want to change it to just hive since we decided to run this test for every commit.