### PR TITLE
Bring release CI changes from erigon upstream

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,32 +13,34 @@ on:
       - 'v*.*.*'
       # to be used by fork patch-releases ^^
       - 'v*.*.*-*'
+  workflow_dispatch:
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@master
+      - name: dockerhub-login
+        uses: docker/login-action@v2
         with:
-          go-version: 1.18.x
+          username: ${{ secrets.DOCKERHUB }}
+          password: ${{ secrets.DOCKERHUB_KEY }}
 
       - name: Prepare
         id: prepare
         run: |
-            TAG=${GITHUB_REF#refs/tags/}
-            echo ::set-output name=tag_name::${TAG}
+          TAG=${GITHUB_REF#refs/tags/}
+          echo ::set-output name=tag_name::${TAG}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Run GoReleaser
         run: |
-            make release
+          make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.prepare.outputs.tag_name }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,64 +9,58 @@ builds:
   - id: darwin-amd64
     main: ./cmd/erigon
     binary: erigon
-    goos:
-      - darwin
-    goarch:
-      - amd64
+    goos: [ darwin ]
+    goarch: [ amd64 ]
     env:
       - CC=o64-clang
       - CXX=o64-clang++
-    tags:
-      - netgo
-    ldflags:
-      -s -w
+    tags: [ nosqlite, noboltdb, netgo ]
+    ldflags: -s -w
 
   - id: darwin-arm64
     main: ./cmd/erigon
     binary: erigon
-    goos:
-      - darwin
-    goarch:
-      - arm64
+    goos: [ darwin ]
+    goarch: [ arm64 ]
     env:
       - CC=oa64-clang
       - CXX=oa64-clang++
-    tags:
-      - netgo
-    ldflags:
-      -s -w
+    tags: [ nosqlite, noboltdb, netgo ]
+    ldflags: -s -w
 
   - id: linux-amd64
     main: ./cmd/erigon
     binary: erigon
-    goos:
-      - linux
-    goarch:
-      - amd64
+    goos: [ linux ]
+    goarch: [ amd64 ]
     env:
-      - CC=gcc
-      - CXX=g++
-    tags:
-      - netgo
-    ldflags:
-      # We need to build a static binary because we are building in a glibc based system and running in a musl container
-      -s -w -extldflags "-static"
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+    tags: [ nosqlite, noboltdb, netgo ]
+    ldflags: -s -w -extldflags "-static" # We need to build a static binary because we are building in a glibc based system and running in a musl container
 
   - id: linux-arm64
     main: ./cmd/erigon
     binary: erigon
-    goos:
-      - linux
-    goarch:
-      - arm64
+    goos: [ linux ]
+    goarch: [ arm64 ]
     env:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
-    tags:
-      - netgo
-    ldflags:
-      # We need to build a static binary because we are building in a glibc based system and running in a musl container
-      -s -w -extldflags "-static"
+    tags: [ nosqlite, noboltdb, netgo ]
+    ldflags: -s -w -extldflags "-static" # We need to build a static binary because we are building in a glibc based system and running in a musl container
+
+  - id: windows-amd64
+    main: ./cmd/erigon
+    binary: erigon
+    goos: [ windows ]
+    goarch: [ amd64 ]
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    tags: [ nosqlite, noboltdb, netgo ]
+    ldflags: -s -w
+
 
 snapshot:
   name_template: "{{ .Tag }}.next"
@@ -76,6 +70,7 @@ dockers:
       - testinprod/{{ .ProjectName }}:{{ .Version }}-amd64
     dockerfile: Dockerfile.release
     use: buildx
+    skip_push: true
     goarch: amd64
     ids:
       - linux-amd64
@@ -85,6 +80,7 @@ dockers:
   - image_templates:
       - testinprod/{{ .ProjectName }}:{{ .Version }}-arm64
     dockerfile: Dockerfile.release
+    skip_push: true
     use: buildx
     goarch: arm64
     ids:
@@ -94,14 +90,16 @@ dockers:
 
 docker_manifests:
   - name_template: testinprod/{{ .ProjectName }}:{{ .Version }}
+    skip_push: true
     image_templates:
       - testinprod/{{ .ProjectName }}:{{ .Version }}-amd64
       - testinprod/{{ .ProjectName }}:{{ .Version }}-arm64
 
   - name_template: testinprod/{{ .ProjectName }}:latest
+    skip_push: true
     image_templates:
-    - testinprod/{{ .ProjectName }}:{{ .Version }}-amd64
-    - testinprod/{{ .ProjectName }}:{{ .Version }}-arm64
+      - testinprod/{{ .ProjectName }}:{{ .Version }}-amd64
+      - testinprod/{{ .ProjectName }}:{{ .Version }}-arm64
 
 announce:
   slack:

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ release: git-submodules
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
 		--skip-validate
 
-	@docker image tag testinprod/op-erigon:${VERSION:1}-amd64 testinprod/op-erigon:latest
+	@docker manifest push testinprod/op-erigon:latest
 	@docker image push --all-tags testinprod/op-erigon
 
 

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ release: git-submodules
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
 		--skip-validate
 
-	@docker image push --all-tags testinprod/erigon
+	@docker image push --all-tags testinprod/op-erigon
 
 
 # since DOCKER_UID, DOCKER_GID are default initialized to the current user uid/gid,

--- a/Makefile
+++ b/Makefile
@@ -248,8 +248,11 @@ release: git-submodules
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
-		goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--rm-dist --skip-validate
+		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		--clean --skip-validate
+
+	@docker image push --all-tags testinprod/erigon
+
 
 # since DOCKER_UID, DOCKER_GID are default initialized to the current user uid/gid,
 # we need separate envvars to facilitate creation of the erigon user on the host OS.

--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,7 @@ release: git-submodules
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
 		--skip-validate
 
+	@docker image tag testinprod/op-erigon:${VERSION:1}-amd64 testinprod/op-erigon:latest
 	@docker image push --all-tags testinprod/op-erigon
 
 

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ git-submodules:
 	@git submodule update --quiet --init --recursive --force || true
 
 PACKAGE_NAME          := github.com/testinprod-io/op-erigon
-GOLANG_CROSS_VERSION  ?= v1.20.2
+GOLANG_CROSS_VERSION  ?= v1.19.1
 
 .PHONY: release-dry-run
 release-dry-run: git-submodules
@@ -249,7 +249,7 @@ release: git-submodules
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--clean --skip-validate
+		--skip-validate
 
 	@docker image push --all-tags testinprod/erigon
 

--- a/Makefile
+++ b/Makefile
@@ -251,9 +251,11 @@ release: git-submodules
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
 		--skip-validate
 
-	@docker manifest push testinprod/op-erigon:latest
 	@docker image push --all-tags testinprod/op-erigon
-
+	@docker manifest create testinprod/op-erigon:latest \
+		--amend testinprod/op-erigon:$$(echo ${VERSION} | cut -c 2- )-amd64 \
+		--amend testinprod/op-erigon:$$(echo ${VERSION} | cut -c 2- )-arm64
+	@docker manifest push testinprod/op-erigon:latest
 
 # since DOCKER_UID, DOCKER_GID are default initialized to the current user uid/gid,
 # we need separate envvars to facilitate creation of the erigon user on the host OS.

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ git-submodules:
 	@git submodule update --quiet --init --recursive --force || true
 
 PACKAGE_NAME          := github.com/testinprod-io/op-erigon
-GOLANG_CROSS_VERSION  ?= v1.19.1
+GOLANG_CROSS_VERSION  ?= v1.20.2
 
 .PHONY: release-dry-run
 release-dry-run: git-submodules


### PR DESCRIPTION
There are some changes for the release CI workflow in Erigon upstream.
This PR brings the changes from the upstream(commit hash: 6d5a16a4ab63312880d112464b71216105c3a7bf)