### PR TITLE
Rename OP Stack for forkdiff

### DIFF
--- a/forkdiff.yaml
+++ b/forkdiff.yaml
@@ -1,6 +1,6 @@
 title: "op-erigon"  # Define the HTML page title
 footer: |  # define the footer with markdown
-  Fork-diff overview of [op-erigon](https://github.com/testinprod-io/erigon), a fork of [erigon](https://github.com/ledgerwatch/erigon). and execution-engine of the [OP-stack](https://github.com/ethereum-optimism/optimism).
+  Fork-diff overview of [op-erigon](https://github.com/testinprod-io/erigon), a fork of [erigon](https://github.com/ledgerwatch/erigon). and execution-engine of the [OP Stack](https://github.com/ethereum-optimism/optimism).
 base:
   name: ledgerwatch/erigon
   url: https://github.com/ledgerwatch/erigon
@@ -12,7 +12,7 @@ fork:
 def:
   title: "op-erigon"
   description: | # description in markdown
-    This is an overview of the changes in [op-erigon](https://github.com/testinprod-io/erigon), a fork of [erigon](https://github.com/ledgerwatch/erigon), part of the OP-stack.
+    This is an overview of the changes in [op-erigon](https://github.com/testinprod-io/erigon), a fork of [erigon](https://github.com/ledgerwatch/erigon), part of the OP Stack.
     
     There are two more forks of erigon dependencies:
     


### PR DESCRIPTION
Rename from `OP-stack` to `OP Stack`.

We may use https://github.com/testinprod-io/forkdiff to generate html, but I manually updated the html.