### PR TITLE
Add Deposit Tx gasUsed and Fix block Fee Calculation for Otterscan

### DIFF
--- a/cmd/rpcdaemon/commands/otterscan_block_details.go
+++ b/cmd/rpcdaemon/commands/otterscan_block_details.go
@@ -43,7 +43,7 @@ func (api *OtterscanAPIImpl) GetBlockDetails(ctx context.Context, number rpc.Blo
 	if err != nil {
 		return nil, err
 	}
-	feesRes, err := api.delegateBlockFees(ctx, tx, b, senders, chainConfig)
+	feesRes, gasUsedDepositTxRes, err := api.delegateBlockFees(ctx, tx, b, senders, chainConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -52,6 +52,9 @@ func (api *OtterscanAPIImpl) GetBlockDetails(ctx context.Context, number rpc.Blo
 	response["block"] = getBlockRes
 	response["issuance"] = getIssuanceRes
 	response["totalFees"] = hexutil.Uint64(feesRes)
+	if chainConfig.IsOptimism() {
+		response["gasUsedDepositTx"] = hexutil.Uint64(gasUsedDepositTxRes)
+	}
 	return response, nil
 }
 
@@ -89,7 +92,7 @@ func (api *OtterscanAPIImpl) GetBlockDetailsByHash(ctx context.Context, hash com
 	if err != nil {
 		return nil, err
 	}
-	feesRes, err := api.delegateBlockFees(ctx, tx, b, senders, chainConfig)
+	feesRes, gasUsedDepositTxRes, err := api.delegateBlockFees(ctx, tx, b, senders, chainConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -98,5 +101,8 @@ func (api *OtterscanAPIImpl) GetBlockDetailsByHash(ctx context.Context, hash com
 	response["block"] = getBlockRes
 	response["issuance"] = getIssuanceRes
 	response["totalFees"] = hexutil.Uint64(feesRes)
+	if chainConfig.IsOptimism() {
+		response["gasUsedDepositTx"] = hexutil.Uint64(gasUsedDepositTxRes)
+	}
 	return response, nil
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -167,6 +167,10 @@ func NewReceipt(failed bool, cumulativeGasUsed uint64) *Receipt {
 	return r
 }
 
+func (r Receipt) IsDepositTxReceipt() bool {
+	return r.Type == DepositTxType
+}
+
 // EncodeRLP implements rlp.Encoder, and flattens the consensus fields of a receipt
 // into an RLP stream. If no post state is present, byzantium fork is assumed.
 func (r Receipt) EncodeRLP(w io.Writer) error {


### PR DESCRIPTION
## Fix miscalculation of `fees` value for `delegateBlockFees` method

For deposit transaction, no transaction fee is charged in L2 world. `delegateBlockFees` method did not take care of it, and wrongly calculated total fees for each block. Ignore addition when deposit transaction.

## Add new parameter `gasUsedDepositTx` for `ots_getBlockDetails` API

When showing block details (not each tx) on otterscan, there is no way to calculate `gasUsed` only for non-deposit transactions. To make this happen, we include `gasUsedDepositTx`. 

Frontend will now be possible to calculate correct `burntFees`, by using this formula: `(gasUsed - gasUsedDepositTx) * blockBaseFee`.
