### PR TITLE
Disable windows build from release CI workflow

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,17 +50,6 @@ builds:
     tags: [ nosqlite, noboltdb, netgo ]
     ldflags: -s -w -extldflags "-static" # We need to build a static binary because we are building in a glibc based system and running in a musl container
 
-  - id: windows-amd64
-    main: ./cmd/erigon
-    binary: erigon
-    goos: [ windows ]
-    goarch: [ amd64 ]
-    env:
-      - CC=x86_64-w64-mingw32-gcc
-      - CXX=x86_64-w64-mingw32-g++
-    tags: [ nosqlite, noboltdb, netgo ]
-    ldflags: -s -w
-
 
 snapshot:
   name_template: "{{ .Tag }}.next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,6 +50,17 @@ builds:
     tags: [ nosqlite, noboltdb, netgo ]
     ldflags: -s -w -extldflags "-static" # We need to build a static binary because we are building in a glibc based system and running in a musl container
 
+#  - id: windows-amd64
+#    main: ./cmd/erigon
+#    binary: erigon
+#    goos: [ windows ]
+#    goarch: [ amd64 ]
+#    env:
+#      - CC=x86_64-w64-mingw32-gcc
+#      - CXX=x86_64-w64-mingw32-g++
+#    tags: [ nosqlite, noboltdb, netgo ]
+#    ldflags: -s -w
+
 
 snapshot:
   name_template: "{{ .Tag }}.next"


### PR DESCRIPTION
op-erigon is not yet tested in Windows.
Disable building windows binary from release cI workflow. it will be recovered after getting confirmed working on windows.