### PR TITLE
Add addPeer RPC

### DIFF
--- a/cmd/erigon-el/backend/backend.go
+++ b/cmd/erigon-el/backend/backend.go
@@ -926,6 +926,16 @@ func (s *Ethereum) Peers(ctx context.Context) (*remote.PeersReply, error) {
 	return &reply, nil
 }
 
+func (s *Ethereum) AddPeer(ctx context.Context, req *remote.AddPeerRequest) (*remote.AddPeerReply, error) {
+	for _, sentryClient := range s.sentriesClient.Sentries() {
+		result, err := sentryClient.AddPeer(ctx, &proto_sentry.AddPeerRequest{Url: req.Url})
+		if err != nil {
+			return &remote.AddPeerReply{Success: result.Success}, fmt.Errorf("ethereum backend MultiClient.AddPeers error: %w", err)
+		}
+	}
+	return &remote.AddPeerReply{Success: true}, nil
+}
+
 // Protocols returns all the currently configured
 // network protocols to start.
 func (s *Ethereum) Protocols() []p2p.Protocol {

--- a/cmd/erigon-el/backend/backend.go
+++ b/cmd/erigon-el/backend/backend.go
@@ -928,9 +928,9 @@ func (s *Ethereum) Peers(ctx context.Context) (*remote.PeersReply, error) {
 
 func (s *Ethereum) AddPeer(ctx context.Context, req *remote.AddPeerRequest) (*remote.AddPeerReply, error) {
 	for _, sentryClient := range s.sentriesClient.Sentries() {
-		result, err := sentryClient.AddPeer(ctx, &proto_sentry.AddPeerRequest{Url: req.Url})
+		_, err := sentryClient.AddPeer(ctx, &proto_sentry.AddPeerRequest{Url: req.Url})
 		if err != nil {
-			return &remote.AddPeerReply{Success: result.Success}, fmt.Errorf("ethereum backend MultiClient.AddPeers error: %w", err)
+			return nil, fmt.Errorf("ethereum backend MultiClient.AddPeers error: %w", err)
 		}
 	}
 	return &remote.AddPeerReply{Success: true}, nil

--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -196,6 +196,7 @@ The following table shows the current implementation status of Erigon's RPC daem
 | ------------------------------------------ |---------|--------------------------------------|
 | admin_nodeInfo                             | Yes     |                                      |
 | admin_peers                                | Yes     |                                      |
+| admin_addPeer                              | Yes     |                                      |
 |                                            |         |                                      |
 | web3_clientVersion                         | Yes     |                                      |
 | web3_sha3                                  | Yes     |                                      |

--- a/cmd/rpcdaemon/commands/admin_api.go
+++ b/cmd/rpcdaemon/commands/admin_api.go
@@ -57,5 +57,8 @@ func (api *AdminAPIImpl) AddPeer(ctx context.Context, url string) (bool, error) 
 	if err != nil {
 		return false, err
 	}
+	if result == nil {
+		return false, errors.New("nil addPeer response")
+	}
 	return result.Success, nil
 }

--- a/cmd/rpcdaemon/commands/admin_api.go
+++ b/cmd/rpcdaemon/commands/admin_api.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ledgerwatch/erigon-lib/gointerfaces/remote"
 	"github.com/ledgerwatch/erigon/p2p"
 	"github.com/ledgerwatch/erigon/turbo/rpchelper"
 )
@@ -17,6 +18,9 @@ type AdminAPI interface {
 	// Peers returns information about the connected remote nodes.
 	// https://geth.ethereum.org/docs/rpc/ns-admin#admin_peers
 	Peers(ctx context.Context) ([]*p2p.PeerInfo, error)
+
+	// AddPeer requests connecting to a remote node.
+	AddPeer(ctx context.Context, url string) (bool, error)
 }
 
 // AdminAPIImpl data structure to store things needed for admin_* commands.
@@ -46,4 +50,12 @@ func (api *AdminAPIImpl) NodeInfo(ctx context.Context) (*p2p.NodeInfo, error) {
 
 func (api *AdminAPIImpl) Peers(ctx context.Context) ([]*p2p.PeerInfo, error) {
 	return api.ethBackend.Peers(ctx)
+}
+
+func (api *AdminAPIImpl) AddPeer(ctx context.Context, url string) (bool, error) {
+	result, err := api.ethBackend.AddPeer(ctx, &remote.AddPeerRequest{Url: url})
+	if err != nil {
+		return false, err
+	}
+	return result.Success, nil
 }

--- a/cmd/rpcdaemon/rpcservices/eth_backend.go
+++ b/cmd/rpcdaemon/rpcservices/eth_backend.go
@@ -306,6 +306,14 @@ func (back *RemoteBackend) Peers(ctx context.Context) ([]*p2p.PeerInfo, error) {
 	return peers, nil
 }
 
+func (back *RemoteBackend) AddPeer(ctx context.Context, request *remote.AddPeerRequest) (*remote.AddPeerReply, error) {
+	result, err := back.remoteEthBackend.AddPeer(ctx, request)
+	if err != nil {
+		return nil, fmt.Errorf("ETHBACKENDClient.AddPeer() error: %w", err)
+	}
+	return result, nil
+}
+
 func (back *RemoteBackend) PendingBlock(ctx context.Context) (*types.Block, error) {
 	blockRlp, err := back.remoteEthBackend.PendingBlock(ctx, &emptypb.Empty{})
 	if err != nil {

--- a/cmd/sentry/sentry/sentry_grpc_server.go
+++ b/cmd/sentry/sentry/sentry_grpc_server.go
@@ -1185,6 +1185,15 @@ func (ss *GrpcServer) PeerEvents(req *proto_sentry.PeerEventsRequest, server pro
 	}
 }
 
+func (ss *GrpcServer) AddPeer(_ context.Context, req *proto_sentry.AddPeerRequest) (*proto_sentry.AddPeerReply, error) {
+	node, err := enode.Parse(enode.ValidSchemes, req.Url)
+	if err != nil {
+		return nil, err
+	}
+	ss.P2pServer.AddPeer(node)
+	return &proto_sentry.AddPeerReply{Success: true}, nil
+}
+
 func (ss *GrpcServer) NodeInfo(_ context.Context, _ *emptypb.Empty) (*proto_types.NodeInfoReply, error) {
 	if ss.P2pServer == nil {
 		return nil, errors.New("p2p server was not started")

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1029,6 +1029,16 @@ func (s *Ethereum) Peers(ctx context.Context) (*remote.PeersReply, error) {
 	return &reply, nil
 }
 
+func (s *Ethereum) AddPeer(ctx context.Context, req *remote.AddPeerRequest) (*remote.AddPeerReply, error) {
+	for _, sentryClient := range s.sentriesClient.Sentries() {
+		result, err := sentryClient.AddPeer(ctx, &proto_sentry.AddPeerRequest{Url: req.Url})
+		if err != nil {
+			return &remote.AddPeerReply{Success: result.Success}, fmt.Errorf("ethereum backend MultiClient.AddPeers error: %w", err)
+		}
+	}
+	return &remote.AddPeerReply{Success: true}, nil
+}
+
 // Protocols returns all the currently configured
 // network protocols to start.
 func (s *Ethereum) Protocols() []p2p.Protocol {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1031,9 +1031,9 @@ func (s *Ethereum) Peers(ctx context.Context) (*remote.PeersReply, error) {
 
 func (s *Ethereum) AddPeer(ctx context.Context, req *remote.AddPeerRequest) (*remote.AddPeerReply, error) {
 	for _, sentryClient := range s.sentriesClient.Sentries() {
-		result, err := sentryClient.AddPeer(ctx, &proto_sentry.AddPeerRequest{Url: req.Url})
+		_, err := sentryClient.AddPeer(ctx, &proto_sentry.AddPeerRequest{Url: req.Url})
 		if err != nil {
-			return &remote.AddPeerReply{Success: result.Success}, fmt.Errorf("ethereum backend MultiClient.AddPeers error: %w", err)
+			return nil, fmt.Errorf("ethereum backend MultiClient.AddPeers error: %w", err)
 		}
 	}
 	return &remote.AddPeerReply{Success: true}, nil

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -80,6 +80,7 @@ type EthBackend interface {
 	NetPeerCount() (uint64, error)
 	NodesInfo(limit int) (*remote.NodesInfoReply, error)
 	Peers(ctx context.Context) (*remote.PeersReply, error)
+	AddPeer(ctx context.Context, url *remote.AddPeerRequest) (*remote.AddPeerReply, error)
 }
 
 func NewEthBackendServer(ctx context.Context, eth EthBackend, db kv.RwDB, events *shards.Events, blockReader services.BlockAndTxnReader,
@@ -894,6 +895,10 @@ func (s *EthBackendServer) NodeInfo(_ context.Context, r *remote.NodesInfoReques
 
 func (s *EthBackendServer) Peers(ctx context.Context, _ *emptypb.Empty) (*remote.PeersReply, error) {
 	return s.eth.Peers(ctx)
+}
+
+func (s *EthBackendServer) AddPeer(ctx context.Context, url *remote.AddPeerRequest) (*remote.AddPeerReply, error) {
+	return s.eth.AddPeer(ctx, url)
 }
 
 func (s *EthBackendServer) SubscribeLogs(server remote.ETHBACKEND_SubscribeLogsServer) (err error) {

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -897,8 +897,8 @@ func (s *EthBackendServer) Peers(ctx context.Context, _ *emptypb.Empty) (*remote
 	return s.eth.Peers(ctx)
 }
 
-func (s *EthBackendServer) AddPeer(ctx context.Context, url *remote.AddPeerRequest) (*remote.AddPeerReply, error) {
-	return s.eth.AddPeer(ctx, url)
+func (s *EthBackendServer) AddPeer(ctx context.Context, req *remote.AddPeerRequest) (*remote.AddPeerReply, error) {
+	return s.eth.AddPeer(ctx, req)
 }
 
 func (s *EthBackendServer) SubscribeLogs(server remote.ETHBACKEND_SubscribeLogsServer) (err error) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ledgerwatch/erigon
 go 1.19
 
 //fork with minor protobuf file changes and txpool support
-replace github.com/ledgerwatch/erigon-lib v0.0.0-20230423044930-fc9dd74e6407 => github.com/testinprod-io/erigon-lib v0.0.0-20230510042408-cab68978c512
+replace github.com/ledgerwatch/erigon-lib v0.0.0-20230423044930-fc9dd74e6407 => github.com/testinprod-io/erigon-lib v0.0.0-20230515052831-22f1acf7ed87
 
 //for local dev:
 //replace github.com/ledgerwatch/erigon-lib v0.0.0-20230423044930-fc9dd74e6407 => ../erigon-lib

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ledgerwatch/erigon
 go 1.19
 
 //fork with minor protobuf file changes and txpool support
-replace github.com/ledgerwatch/erigon-lib v0.0.0-20230423044930-fc9dd74e6407 => github.com/testinprod-io/erigon-lib v0.0.0-20230515052831-22f1acf7ed87
+replace github.com/ledgerwatch/erigon-lib v0.0.0-20230423044930-fc9dd74e6407 => github.com/testinprod-io/erigon-lib v0.0.0-20230616053951-ae06f5d5c536
 
 //for local dev:
 //replace github.com/ledgerwatch/erigon-lib v0.0.0-20230423044930-fc9dd74e6407 => ../erigon-lib

--- a/go.sum
+++ b/go.sum
@@ -777,8 +777,8 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/supranational/blst v0.3.10 h1:CMciDZ/h4pXDDXQASe8ZGTNKUiVNxVVA5hpci2Uuhuk=
 github.com/supranational/blst v0.3.10/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/testinprod-io/erigon-lib v0.0.0-20230510042408-cab68978c512 h1:W4E/VTA0MZuvM/M9Bu4EUxKuvR/Lg3S7Ae2PUbC2xZM=
-github.com/testinprod-io/erigon-lib v0.0.0-20230510042408-cab68978c512/go.mod h1:Riqyql8ODsUgb2bXD7RYC4p7Osbq4019/lPin3/eESA=
+github.com/testinprod-io/erigon-lib v0.0.0-20230515052831-22f1acf7ed87 h1:74149f7RmSu/6H4FBFhiZ9LJeH6X30v1kezMNwb0vWQ=
+github.com/testinprod-io/erigon-lib v0.0.0-20230515052831-22f1acf7ed87/go.mod h1:Mpjyg6x94c87gb5N5hD6grP0tJpGL8yL6ZDeKkA+828=
 github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e h1:cR8/SYRgyQCt5cNCMniB/ZScMkhI9nk8U5C7SbISXjo=
 github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e/go.mod h1:Tu4lItkATkonrYuvtVjG0/rhy15qrNGNTjPdaphtZ/8=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=

--- a/go.sum
+++ b/go.sum
@@ -777,8 +777,8 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/supranational/blst v0.3.10 h1:CMciDZ/h4pXDDXQASe8ZGTNKUiVNxVVA5hpci2Uuhuk=
 github.com/supranational/blst v0.3.10/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/testinprod-io/erigon-lib v0.0.0-20230515052831-22f1acf7ed87 h1:74149f7RmSu/6H4FBFhiZ9LJeH6X30v1kezMNwb0vWQ=
-github.com/testinprod-io/erigon-lib v0.0.0-20230515052831-22f1acf7ed87/go.mod h1:Mpjyg6x94c87gb5N5hD6grP0tJpGL8yL6ZDeKkA+828=
+github.com/testinprod-io/erigon-lib v0.0.0-20230616053951-ae06f5d5c536 h1:xootH/fjZSJ0VNE3v0cGU1PleXRsqaseAyvjUWUDh8U=
+github.com/testinprod-io/erigon-lib v0.0.0-20230616053951-ae06f5d5c536/go.mod h1:6SIBkeREz7fob8A0EBsTCVzTqJIc+BBiuPAsb5sUYk0=
 github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e h1:cR8/SYRgyQCt5cNCMniB/ZScMkhI9nk8U5C7SbISXjo=
 github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e/go.mod h1:Tu4lItkATkonrYuvtVjG0/rhy15qrNGNTjPdaphtZ/8=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=

--- a/turbo/rpchelper/interface.go
+++ b/turbo/rpchelper/interface.go
@@ -31,6 +31,7 @@ type ApiBackend interface {
 	EngineGetBlobsBundleV1(ctx context.Context, payloadId uint64) (*types2.BlobsBundleV1, error)
 	NodeInfo(ctx context.Context, limit uint32) ([]p2p.NodeInfo, error)
 	Peers(ctx context.Context) ([]*p2p.PeerInfo, error)
+	AddPeer(ctx context.Context, url *remote.AddPeerRequest) (*remote.AddPeerReply, error)
 	PendingBlock(ctx context.Context) (*types.Block, error)
 	EngineGetPayloadBodiesByHashV1(ctx context.Context, request *remote.EngineGetPayloadBodiesByHashV1Request) (*remote.EngineGetPayloadBodiesV1Response, error)
 	EngineGetPayloadBodiesByRangeV1(ctx context.Context, request *remote.EngineGetPayloadBodiesByRangeV1Request) (*remote.EngineGetPayloadBodiesV1Response, error)


### PR DESCRIPTION
Actual implementation for admin_addPeer method.
RPC Spec: Refer to https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-admin.
> The addPeer administrative method requests adding a new remote node to the list of tracked static nodes. The node will try to maintain connectivity to these nodes at all times, reconnecting every once in a while if the remote connection goes down.

Requires https://github.com/testinprod-io/erigon-lib/pull/12.

Integration test will be done using https://github.com/testinprod-io/hive. Will link related PR here when implemented. Manually checked that RLPx handshake works and tx propagates using this RPC.


Use below example curl command for testing.
```
curl --location 'localhost:8545/' \
--header 'Content-Type: application/json' \
--data '{
	"jsonrpc":"2.0",
	"method":"admin_addPeer",
	"params":["enode://[nodeId]@[ip]:[port]"],
	"id":13371337
}' 
```

Note that even if RPC response returns `true`, it does not guarantee that RLPx protocol is established between peers. It just adds node entrypoint to its static peer list, and periodically tries and tests connections.

This behavior is same with geth.



