### PR TITLE
Disable download-page workflow

### DIFF
--- a/.github/workflows/download-page.yml
+++ b/.github/workflows/download-page.yml
@@ -1,21 +1,21 @@
-#name: Trigger After Release
-#
-#on:
+name: Trigger After Release
+
+on: workflow_dispatch
 #  workflow_run:
 #    workflows: ["release"]
 #    types:
 #      - completed
-#
-#jobs:
-#  after_release:
-#    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v3
-#
-#      - name: Publish downloads
-#        run: |
-#          cd cmd/release
-#          docker buildx build --push --platform linux/amd64 --build-arg GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" -t thorax/download:latest .
+
+jobs:
+  after_release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Publish downloads
+        run: |
+          cd cmd/release 
+          docker buildx build --push --platform linux/amd64 --build-arg GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" -t thorax/download:latest .

--- a/.github/workflows/download-page.yml
+++ b/.github/workflows/download-page.yml
@@ -1,21 +1,21 @@
-name: Trigger After Release
-
-on:
-  workflow_run:
-    workflows: ["release"]
-    types:
-      - completed
-
-jobs:
-  after_release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Publish downloads
-        run: |
-          cd cmd/release 
-          docker buildx build --push --platform linux/amd64 --build-arg GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" -t thorax/download:latest .
+#name: Trigger After Release
+#
+#on:
+#  workflow_run:
+#    workflows: ["release"]
+#    types:
+#      - completed
+#
+#jobs:
+#  after_release:
+#    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v3
+#
+#      - name: Publish downloads
+#        run: |
+#          cd cmd/release
+#          docker buildx build --push --platform linux/amd64 --build-arg GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" -t thorax/download:latest .


### PR DESCRIPTION
https://github.com/testinprod-io/op-erigon/actions/runs/5053438042

- Disable download-page workflow for now
- Change Github actions trigger event to `workflow_dispatch` (manual trigger only)
