### PR TITLE
Bedrock DB Migration

### DIFF
--- a/bedrock-migration.md
+++ b/bedrock-migration.md
@@ -27,7 +27,7 @@ git clone https://github.com/testinprod-io/op-geth
 cd op-geth
 git switch pcw109550/bedrock-db-migration
 make geth
-./migrate.sh [bedrock_start_block_num] [geth_bedrock_archive_location] 2>&1 | tee migration.log
+./migrate.sh [bedrock_start_block_num] [geth_bedrock_archive_location] [optional:artifact_path] 2>&1 | tee migration.log
 # ex) ./migrate.sh 4061224 /home/ubuntu/geth_db  2>&1 | tee migration.log
 ```
 
@@ -90,7 +90,7 @@ git clone https://github.com/testinprod-io/op-erigon
 cd op-erigon
 git switch pcw109550/bedrock-db-migration
 make erigon
-./migrate.sh [chain_name] [bedrock_start_block_num] 2>&1 | tee migration.log
+./migrate.sh [chain_name] [bedrock_start_block_num] [optional:artifact_path] [optional:erigon_db_path] 2>&1 | tee migration.log
 # ex) ./migrate.sh optimism-goerli 4061224 2>&1 | tee migration.log
 # chain name must be optimism-mainnet or optimism-goerli
 ```

--- a/bedrock-migration.md
+++ b/bedrock-migration.md
@@ -31,7 +31,7 @@ make geth
 # ex) ./migrate.sh 4061224 /home/ubuntu/geth_db  2>&1 | tee migration.log
 ```
 
-[`migrate.sh`](./migrate.sh) executes below steps.
+[`migrate.sh`](https://github.com/testinprod-io/op-geth/blob/pcw109550/bedrock-db-migration/migrate.sh) executes below steps.
 
 * [Export Blocks](#export-blocks)
 * [Export Receipts](#export-receipts)
@@ -95,7 +95,7 @@ make erigon
 # chain name must be optimism-mainnet or optimism-goerli
 ```
 
-[`migrate.sh`](https://github.com/testinprod-io/op-geth/blob/pcw109550/bedrock-db-migration/migrate.sh) executes below steps.
+[`migrate.sh`](./migrate.sh) executes below steps.
 
 * [Import Genesis](#import-genesis)
 * [Recover Genesis](#recover-genesis)
@@ -108,7 +108,7 @@ make erigon
 * [Recover Senders](#recover-senders)
 
 All artifacts will be fetched from `/tmp/migration-artifact`.
-After database creation, we can sanity check state trie by below step. This sanity check step is not included in [`migrate.sh`](https://github.com/testinprod-io/op-geth/blob/pcw109550/bedrock-db-migration/migrate.sh).
+After database creation, we can sanity check state trie by below step. This sanity check step is not included in [`migrate.sh`](./migrate.sh).
 
 * [Sanity Check](#sanity-check)
 

--- a/bedrock-migration.md
+++ b/bedrock-migration.md
@@ -1,0 +1,124 @@
+## op-migrate
+
+This docs performs database migration for erigon from geth.
+
+### Input
+
+Bedrock archive for op-geth.
+
+### Output
+
+Bedrock archive for op-erigon.
+
+### Export
+
+```sh
+git clone https://github.com/testinprod-io/op-geth
+cd op-geth
+git switch pcw109550/bedrock-db-migration
+make geth
+```
+
+#### Export Blocks
+
+```sh
+./build/bin/geth --datadir=goerli-bedrock-archive --nodiscover export blocks_0_4061224.rlp 0 4061224
+```
+
+#### Export Receipts
+
+```sh
+./build/bin/geth --datadir=goerli-bedrock-archive --nodiscover export-receipts receipts_0_4061223.rlp 0 4061223
+```
+
+#### Export State
+
+```
+./build/bin/geth --datadir=goerli-bedrock-archive --nodiscover dump --iterative 4061224 > world_trie_state_4061224.jsonl
+```
+or
+```
+./build/bin/geth --datadir=goerli-bedrock-archive --nodiscover dump 4061224 > world_trie_state_4061224.json
+```
+
+#### Export Total Difficulty
+
+```sh
+./build/bin/geth --datadir=goerli-bedrock-archive --nodiscover export-totaldifficulty totaldifficulty_0_4061224.rlp 0 4061224
+```
+
+### Import
+
+```sh
+git clone https://github.com/testinprod-io/op-erigon
+cd op-erigon
+git switch pcw109550/bedrock-db-migration
+make erigon
+```
+
+#### Import Genesis
+
+```sh
+./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli init genesis.json
+```
+
+#### Recover Genesis
+
+```sh
+./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover  --chain=optimism-goerli recover-regenesis
+```
+
+#### Import Block
+
+```
+./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli import blocks_0_4061224.rlp
+```
+
+#### Import Total Difficulty
+
+```
+./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli import-totaldifficulty totaldifficulty_0_4061224.rlp
+```
+
+
+#### Import Receipts
+
+```sh
+./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli import-receipts receipts_0_4061223.rlp
+```
+
+#### Import State
+
+```sh
+./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli import-state world_trie_state_4061224.jsonl 4061224
+```
+or 
+```sh
+./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli --import.stream=false import-state world_trie_state_4061224.json 4061224
+```
+
+### Recovery
+
+#### Drop Log Index
+
+```sh
+./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli drop-log-index
+```
+
+#### Recover Log Index
+
+```sh
+./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli recover-log-index 0 4061224
+```
+
+#### Recover Senders
+
+```sh
+./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli recover-senders 0 4061224
+```
+
+### Sanity Check
+
+```sh
+./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli sanity-check 4061224
+```

--- a/bedrock-migration.md
+++ b/bedrock-migration.md
@@ -2,6 +2,16 @@
 
 This docs performs database migration for erigon from geth.
 
+Run below steps for migration:
+
+* [Export](#export)
+* [Import](#import)
+* (Optional) [Sanity Check](#sanity-check)
+
+While migration, monitor resources:
+
+* [Resource Monitor](#resource-monitor)
+
 ### Input
 
 Bedrock archive for op-geth.
@@ -17,9 +27,29 @@ git clone https://github.com/testinprod-io/op-geth
 cd op-geth
 git switch pcw109550/bedrock-db-migration
 make geth
+./migrate.sh [bedrock_start_block_num] [geth_bedrock_archive_location] 2>&1 | tee migration.log
+# ex) ./migrate.sh 4061224 /home/ubuntu/geth_db  2>&1 | tee migration.log
+```
+
+[`migrate.sh`](./migrate.sh) executes below steps.
+
+* [Export Blocks](#export-blocks)
+* [Export Receipts](#export-receipts)
+* [Export State](#export-state)
+* [Export Total Difficulty](#export-total-difficulty)
+
+All artifacts will be saved under `/tmp/migration-artifact`.
+Example artifact sizes for optimisim goerli:
+```
+-rwxr-xr-x   1 changwan.park  wheel  4976571501 May 30 16:11 blocks.rlp
+-rwxr-xr-x   1 changwan.park  wheel  3921257677 May 30 16:16 receipts.rlp
+-rwxr-xr-x   1 changwan.park  wheel    16211937 May 30 16:12 totaldifficulty.rlp
+-rw-r--r--   1 changwan.park  wheel  1485267744 May 30 16:20 world_trie_state.jsonl
 ```
 
 #### Export Blocks
+
+Export block(block header + body(transactions)) in rlp format.
 
 ```sh
 ./build/bin/geth --datadir=goerli-bedrock-archive --nodiscover export blocks_0_4061224.rlp 0 4061224
@@ -27,11 +57,15 @@ make geth
 
 #### Export Receipts
 
+Export transaction receipts in rlp format.
+
 ```sh
-./build/bin/geth --datadir=goerli-bedrock-archive --nodiscover export-receipts receipts_0_4061223.rlp 0 4061223
+./build/bin/geth --datadir=goerli-bedrock-archive --nodiscover export-receipts receipts_0_4061224.rlp 0 4061224
 ```
 
 #### Export State
+
+Export world state trie in json or jsonl format. For data stream, you must use jsonl format. Give `--iterative` flag for jsonl output.
 
 ```
 ./build/bin/geth --datadir=goerli-bedrock-archive --nodiscover dump --iterative 4061224 > world_trie_state_4061224.jsonl
@@ -42,6 +76,8 @@ or
 ```
 
 #### Export Total Difficulty
+
+Export total difficulty in rlp format.
 
 ```sh
 ./build/bin/geth --datadir=goerli-bedrock-archive --nodiscover export-totaldifficulty totaldifficulty_0_4061224.rlp 0 4061224
@@ -54,9 +90,31 @@ git clone https://github.com/testinprod-io/op-erigon
 cd op-erigon
 git switch pcw109550/bedrock-db-migration
 make erigon
+./migrate.sh [chain_name] [bedrock_start_block_num] 2>&1 | tee migration.log
+# ex) ./migrate.sh optimism-goerli 4061224 2>&1 | tee migration.log
+# chain name must be optimism-mainnet or optimism-goerli
 ```
 
+[`migrate.sh`](https://github.com/testinprod-io/op-geth/blob/pcw109550/bedrock-db-migration/migrate.sh) executes below steps.
+
+* [Import Genesis](#import-genesis)
+* [Recover Genesis](#recover-genesis)
+* [Import Block](#import-block)
+* [Import Total Difficulty](#import-total-difficulty)
+* [Import Receipts](#import-receipts)
+* [Import State](#import-state)
+* [Drop Log Index](#drop-log-index)
+* [Recover Log Index](#recover-log-index)
+* [Recover Senders](#recover-senders)
+
+All artifacts will be fetched from `/tmp/migration-artifact`.
+After database creation, we can sanity check state trie by below step. This sanity check step is not included in [`migrate.sh`](https://github.com/testinprod-io/op-geth/blob/pcw109550/bedrock-db-migration/migrate.sh).
+
+* [Sanity Check](#sanity-check)
+
 #### Import Genesis
+
+Import genesis json and create db containing chainconfig. Due to bedrock regenesis, allocation from genesis will be set to null and cause wrong header hash and state trie root. This will be fixed using [recover genesis](#recover-genesis) command
 
 ```sh
 ./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli init genesis.json
@@ -64,17 +122,23 @@ make erigon
 
 #### Recover Genesis
 
+Correct genesis block's hash and state trie root.
+
 ```sh
-./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover  --chain=optimism-goerli recover-regenesis
+./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli recover-regenesis
 ```
 
 #### Import Block
+
+Import block(block header + body(transactions)) in rlp format.
 
 ```
 ./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli import blocks_0_4061224.rlp
 ```
 
 #### Import Total Difficulty
+
+Import total difficulty in rlp format.
 
 ```
 ./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli import-totaldifficulty totaldifficulty_0_4061224.rlp
@@ -83,11 +147,15 @@ make erigon
 
 #### Import Receipts
 
+Import transaction receipts in rlp format.
+
 ```sh
 ./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli import-receipts receipts_0_4061223.rlp
 ```
 
 #### Import State
+
+Import world state trie in json or jsonl format. For data stream, you must use jsonl format. Default is to use stream. Use `--import.stream` flag to disable streaming.
 
 ```sh
 ./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli import-state world_trie_state_4061224.jsonl 4061224
@@ -101,11 +169,15 @@ or
 
 #### Drop Log Index
 
+Drop log index table for recovery. In theory table will be already empty, but just to be safe, explicity drop the table. Empty table is required for [recovering log index](#recover-log-index).
+
 ```sh
 ./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli drop-log-index
 ```
 
 #### Recover Log Index
+
+Recover log index table. The logic assumes that log index table is empty.
 
 ```sh
 ./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli recover-log-index 0 4061224
@@ -113,12 +185,24 @@ or
 
 #### Recover Senders
 
+Recover senders table.
+
 ```sh
 ./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli recover-senders 0 4061224
 ```
 
 ### Sanity Check
 
+Sanity check state trie root of specific block.
+
 ```sh
 ./build/bin/erigon --datadir=goerli-bedrock-archive-erigon --nodiscover --chain=optimism-goerli sanity-check 4061224
 ```
+
+### Resource Monitor
+
+```sh
+docker-compose up prometheus grafana
+```
+
+For monitoring resource comsumption.

--- a/cmd/prometheus/grafana.ini
+++ b/cmd/prometheus/grafana.ini
@@ -312,7 +312,7 @@ level = warn
 #################################### Anonymous Auth ######################
 [auth.anonymous]
 # enable anonymous access
-enabled = true
+enabled = false
 
 # specify organization name that should be used for unauthenticated users
 ;org_name = Main Org.

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -800,6 +800,11 @@ var (
 		Name:  "import.execution",
 		Usage: "Execution when importing chain",
 	}
+	ImportStateStreamFlag = cli.BoolFlag{
+		Name:  "import.stream",
+		Usage: "Stream data for State import using jsonl form. (default = true)",
+		Value: true,
+	}
 	GenesisPathFlag = cli.StringFlag{
 		Name:  "genesis.path",
 		Usage: "Genesis JSON file path",
@@ -1670,6 +1675,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	if ctx.IsSet(SentryDropUselessPeers.Name) {
 		cfg.DropUselessPeers = ctx.Bool(SentryDropUselessPeers.Name)
 	}
+	cfg.ImportStateStream = ctx.Bool(ImportStateStreamFlag.Name)
 	cfg.ImportExecution = ctx.IsSet(ImportExecutionFlag.Name)
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -796,6 +796,10 @@ var (
 		Usage: "Port for sentinel",
 		Value: 7777,
 	}
+	ImportExecutionFlag = cli.BoolFlag{
+		Name:  "import.execution",
+		Usage: "Execution when importing chain",
+	}
 	GenesisPathFlag = cli.StringFlag{
 		Name:  "genesis.path",
 		Usage: "Genesis JSON file path",
@@ -1666,6 +1670,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	if ctx.IsSet(SentryDropUselessPeers.Name) {
 		cfg.DropUselessPeers = ctx.Bool(SentryDropUselessPeers.Name)
 	}
+	cfg.ImportExecution = ctx.IsSet(ImportExecutionFlag.Name)
 }
 
 // SetDNSDiscoveryDefaults configures DNS discovery with the given URL if

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -514,6 +514,39 @@ type ReceiptsList []*Receipts
 
 type HackReceipts []*HackReceipt
 
+func (hrs HackReceipts) ConvertToReceipts() (*Receipts, error) {
+	var receipts Receipts
+	for _, hackReceipt := range hrs {
+		feeScalar := new(big.Float)
+		_, success := feeScalar.SetString(hackReceipt.FeeScalar)
+		if !success {
+			return nil, fmt.Errorf("feeScalar convert error")
+		}
+		receipt := Receipt{
+			Type:              hackReceipt.Type,
+			PostState:         hackReceipt.PostState,
+			Status:            hackReceipt.Status,
+			CumulativeGasUsed: hackReceipt.CumulativeGasUsed,
+			Bloom:             hackReceipt.Bloom,
+			Logs:              hackReceipt.Logs,
+			TxHash:            hackReceipt.TxHash,
+			ContractAddress:   hackReceipt.ContractAddress,
+			GasUsed:           hackReceipt.GasUsed,
+			BlockHash:         hackReceipt.BlockHash,
+			BlockNumber:       hackReceipt.BlockNumber,
+			TransactionIndex:  hackReceipt.TransactionIndex,
+			L1GasPrice:        hackReceipt.L1GasPrice,
+			L1GasUsed:         hackReceipt.L1GasUsed,
+			L1Fee:             hackReceipt.L1Fee,
+			FeeScalar:         feeScalar,
+			// no depositnonce before bedrock
+			DepositNonce: nil,
+		}
+		receipts = append(receipts, &receipt)
+	}
+	return &receipts, nil
+}
+
 // Len returns the number of receipts in this list.
 func (rs Receipts) Len() int { return len(rs) }
 

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -515,7 +515,7 @@ type ReceiptsList []*Receipts
 type HackReceipts []*HackReceipt
 
 func (hrs HackReceipts) ConvertToReceipts() (*Receipts, error) {
-	var receipts Receipts
+	receipts := make(Receipts, 0)
 	for _, hackReceipt := range hrs {
 		feeScalar := new(big.Float)
 		_, success := feeScalar.SetString(hackReceipt.FeeScalar)

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -653,3 +653,25 @@ func (r Receipts) DeriveFields(config *chain.Config, hash libcommon.Hash, number
 	}
 	return nil
 }
+
+// ProcessFieldsForValidation drops and populates field for receipt trie root calculation
+func (rs *Receipts) ProcessFieldsForValidation(block *Block) {
+	for i := 0; i < rs.Len(); i++ {
+		txHash := common.Hash{}
+		if len((*rs)[i].Logs) >= 1 {
+			txHash = (*rs)[i].Logs[0].TxHash
+			for j := 0; j < len((*rs)[i].Logs); j++ {
+				(*rs)[i].Logs[j].BlockNumber = 0
+				(*rs)[i].Logs[j].TxHash = common.Hash{}
+				(*rs)[i].Logs[j].TxIndex = 0
+				(*rs)[i].Logs[j].Index = 0
+			}
+		}
+		(*rs)[i].Type = block.Body().Transactions[i].Type()
+		(*rs)[i].BlockHash = block.Hash()
+		(*rs)[i].BlockNumber = block.Number()
+		(*rs)[i].GasUsed = block.GasUsed()
+		(*rs)[i].TxHash = txHash
+		(*rs)[i].Bloom = BytesToBloom(LogsBloom((*rs)[i].Logs))
+	}
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -920,7 +920,8 @@ func (s *Ethereum) StartMining(ctx context.Context, db kv.RwDB, mining *stagedsy
 	return nil
 }
 
-func (s *Ethereum) IsMining() bool { return s.config.Miner.Enabled }
+func (s *Ethereum) IsMining() bool     { return s.config.Miner.Enabled }
+func (s *Ethereum) Dirs() datadir.Dirs { return s.config.Dirs }
 
 func (s *Ethereum) ChainKV() kv.RwDB            { return s.chainDB }
 func (s *Ethereum) NetVersion() (uint64, error) { return s.networkID, nil }

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -182,7 +182,8 @@ type Config struct {
 	Prune     prune.Mode
 	BatchSize datasize.ByteSize // Batch size for execution stage
 
-	ImportMode bool
+	ImportMode      bool
+	ImportExecution bool
 
 	BadBlockHash common.Hash // hash of the block marked as bad
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -182,8 +182,9 @@ type Config struct {
 	Prune     prune.Mode
 	BatchSize datasize.ByteSize // Batch size for execution stage
 
-	ImportMode      bool
-	ImportExecution bool
+	ImportMode        bool
+	ImportStateStream bool
+	ImportExecution   bool
 
 	BadBlockHash common.Hash // hash of the block marked as bad
 

--- a/eth/stagedsync/stage_log_index.go
+++ b/eth/stagedsync/stage_log_index.go
@@ -100,6 +100,10 @@ func SpawnLogIndex(s *StageState, tx kv.RwTx, cfg LogIndexCfg, ctx context.Conte
 	return nil
 }
 
+func PromoteLogIndex(logPrefix string, tx kv.RwTx, start uint64, endBlock uint64, cfg LogIndexCfg, ctx context.Context) error {
+	return promoteLogIndex(logPrefix, tx, start, endBlock, cfg, ctx)
+}
+
 func promoteLogIndex(logPrefix string, tx kv.RwTx, start uint64, endBlock uint64, cfg LogIndexCfg, ctx context.Context) error {
 	quit := ctx.Done()
 	logEvery := time.NewTicker(30 * time.Second)

--- a/eth/stagedsync/stage_log_index.go
+++ b/eth/stagedsync/stage_log_index.go
@@ -126,9 +126,9 @@ func promoteLogIndex(logPrefix string, tx kv.RwTx, start uint64, endBlock uint64
 
 	reader := bytes.NewReader(nil)
 
-	if endBlock != 0 && endBlock-start > 100 {
-		log.Info(fmt.Sprintf("[%s] processing", logPrefix), "from", start, "to", endBlock)
-	}
+	// if endBlock != 0 && endBlock-start > 100 {
+	// 	log.Info(fmt.Sprintf("[%s] processing", logPrefix), "from", start, "to", endBlock)
+	// }
 
 	for k, v, err := logs.Seek(dbutils.LogKey(start, 0)); k != nil; k, v, err = logs.Next() {
 		if err != nil {
@@ -143,7 +143,7 @@ func promoteLogIndex(logPrefix string, tx kv.RwTx, start uint64, endBlock uint64
 		// if endBlock is positive, we only run the stage up until endBlock
 		// if endBlock is zero, we run the stage for all available blocks
 		if endBlock != 0 && blockNum > endBlock {
-			log.Info(fmt.Sprintf("[%s] Reached user-specified end block", logPrefix), "endBlock", endBlock)
+			// log.Info(fmt.Sprintf("[%s] Reached user-specified end block", logPrefix), "endBlock", endBlock)
 			break
 		}
 

--- a/init/optimism-goerli.json
+++ b/init/optimism-goerli.json
@@ -1,0 +1,32 @@
+{
+    "config": {
+        "ChainName": "optimism-goerli",
+        "chainId": 420,
+        "homesteadBlock": 0,
+        "eip150Block": 0,
+        "eip155Block": 0,
+        "eip158Block": 0,
+        "byzantiumBlock": 0,
+        "constantinopleBlock": 0,
+        "petersburgBlock": 0,
+        "istanbulBlock": 0,
+        "muirGlacierBlock": 0,
+        "berlinBlock": 0,
+        "londonBlock": 4061224,
+        "arrowGlacierBlock": 4061224,
+        "grayGlacierBlock": 4061224,
+        "mergeNetsplitBlock": 4061224,
+        "bedrockBlock": 4061224,
+        "terminalTotalDifficulty": 0,
+        "terminalTotalDifficultyPassed": true,
+        "optimism": {
+            "eip1559Elasticity": 10,
+            "eip1559Denominator": 50
+        },
+        "regolithTime": 1679079600
+    },
+    "difficulty": "1",
+    "gasLimit": "15000000",
+    "extradata": "0x000000000000000000000000000000000000000000000000000000000000000027770a9694e4B4b1E130Ab91Bc327C36855f612E0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "alloc": {}
+}

--- a/init/optimism-mainnet.json
+++ b/init/optimism-mainnet.json
@@ -16,14 +16,14 @@
         "arrowGlacierBlock": 3950000,
         "grayGlacierBlock": 3950000,
         "mergeNetsplitBlock": 3950000,
-        "bedrockBlock": "<FIXME>",
+        "bedrockBlock": 105235063,
         "terminalTotalDifficulty": 0,
         "terminalTotalDifficultyPassed": true,
         "optimism": {
-            "eip1559Elasticity": "<FIXME>",
-            "eip1559Denominator": "<FIXME>"
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50
         },
-        "regolithTime": "<FIXME>"
+        "regolithTime": 0
     },
     "difficulty": "1",
     "gasLimit": "15000000",

--- a/init/optimism-mainnet.json
+++ b/init/optimism-mainnet.json
@@ -1,0 +1,32 @@
+{
+    "config": {
+        "ChainName": "optimism-mainnet",
+        "chainId": 10,
+        "homesteadBlock": 0,
+        "eip150Block": 0,
+        "eip155Block": 0,
+        "eip158Block": 0,
+        "byzantiumBlock": 0,
+        "constantinopleBlock": 0,
+        "petersburgBlock": 0,
+        "istanbulBlock": 0,
+        "muirGlacierBlock": 0,
+        "berlinBlock": 3950000,
+        "londonBlock": 3950000,
+        "arrowGlacierBlock": 3950000,
+        "grayGlacierBlock": 3950000,
+        "mergeNetsplitBlock": 3950000,
+        "bedrockBlock": "<FIXME>",
+        "terminalTotalDifficulty": 0,
+        "terminalTotalDifficultyPassed": true,
+        "optimism": {
+            "eip1559Elasticity": "<FIXME>",
+            "eip1559Denominator": "<FIXME>"
+        },
+        "regolithTime": "<FIXME>"
+    },
+    "difficulty": "1",
+    "gasLimit": "15000000",
+    "extradata": "0x000000000000000000000000000000000000000000000000000000000000000000000398232e2064f896018496b4b44b3d62751f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "alloc": {}
+}

--- a/migrate.sh
+++ b/migrate.sh
@@ -7,6 +7,18 @@ banner() {
     echo "|                                          |"
     printf "|$(tput bold) %-40s $(tput sgr0)|\n" "$@"
     echo "+------------------------------------------+"
+    slack_report "$1" > /dev/null
+}
+
+# never fail
+slack_report() {
+    if ! [ -e "slack_report.sh" ]; then
+        echo "slack reporter does not exist" 1>&2
+        return 0
+    fi
+    echo "sending slack message: $1"
+    ./slack_report.sh "$1" || true
+    echo
 }
 
 echo " ____           _                _      __  __ _                 _   _              "

--- a/migrate.sh
+++ b/migrate.sh
@@ -103,3 +103,5 @@ time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$
 
 banner "Recover Senders"
 time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/recover_senders recover-senders 0 "$BEDROCK_START_BLOCK_NUM" 2> /dev/null
+
+slack_report "Import done" > /dev/null

--- a/migrate.sh
+++ b/migrate.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -e
+
+banner() {
+    echo "+------------------------------------------+"
+    printf "| %-40s |\n" "$(date)"
+    echo "|                                          |"
+    printf "|$(tput bold) %-40s $(tput sgr0)|\n" "$@"
+    echo "+------------------------------------------+"
+}
+
+echo " ____           _                _      __  __ _                 _   _              "
+echo " |  _ \         | |              | |    |  \/  (_)               | | (_)            "
+echo " | |_) | ___  __| |_ __ ___   ___| | __ | \  / |_  __ _ _ __ __ _| |_ _  ___  _ __  "
+echo " |  _ < / _ \/ _  |  __/ _ \ / __| |/ / | |\/| | |/ _  | '__/ _  | __| |/ _ \| '_ \ "
+echo " | |_) |  __/ (_| | | | (_) | (__|   <  | |  | | | (_| | | | (_| | |_| | (_) | | | |"
+echo " |____/ \___|\__,_|_|  \___/ \___|_|\_\ |_|  |_|_|\__, |_|  \__,_|\__|_|\___/|_| |_|"
+echo "                                                   __/ |                            "
+echo "                                                  |___/                             "
+
+ERIGON_DATA_DIR="erigon_db"
+CHAIN="optimism-goerli"
+LOG_DIR="migration-log"
+
+if [[ -n "$1" ]]; then
+    if [[ "$1" == "optimism-goerli" || "$1" == "optimism-mainnet" ]]; then
+        CHAIN=$1
+    else
+        echo "invalid value for chain name. Must be either 'optimism-goerli' or 'optimism-mainnet'"
+        exit 1
+    fi
+else
+    echo "chain name not set."
+    exit 1
+fi
+
+if [[ -n "$2" ]]; then
+    BEDROCK_START_BLOCK_NUM=$2
+else
+    echo "bedrock start block number not set."
+    exit 1
+fi
+
+if [ ! -d "$LOG_DIR" ]; then
+    mkdir "$LOG_DIR"
+fi
+
+ARTIFACT_PATH="/tmp/migration-artifact"
+if [ ! -d "$ARTIFACT_PATH" ]; then
+    mkdir "$ARTIFACT_PATH"
+fi
+
+EXTRA_FLAGS="--no-downloader --nodiscover --maxpeers=0 --txpool.disable"
+EXTRA_FLAGS="$EXTRA_FLAGS --log.console.verbosity=3"
+EXTRA_FLAGS="$EXTRA_FLAGS --chain=$CHAIN"
+
+banner "Import Genesis"
+time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/init_genesis init init/"$CHAIN".json 2> /dev/null
+
+banner "Recover Genesis"
+time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/recover_genesis recover-regenesis 2> /dev/null
+
+banner "Import Blocks"
+time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/import_block import $ARTIFACT_PATH/blocks.rlp 2> /dev/null
+
+banner "Import Total Difficulty"
+time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/import_totaldifficulty import-totaldifficulty $ARTIFACT_PATH/totaldifficulty.rlp 2> /dev/null
+
+banner "Import Receipts"
+time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/import_receipts import-receipts $ARTIFACT_PATH/receipts.rlp 2> /dev/null
+
+banner "Import State"
+time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/import_state import-state $ARTIFACT_PATH/world_trie_state.jsonl "$BEDROCK_START_BLOCK_NUM" 2> /dev/null
+
+banner "Drop Log Index"
+time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/drop_log_index drop-log-index 2> /dev/null
+
+banner "Recover Log Index"
+time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/recover_log_index recover-log-index 0 "$BEDROCK_START_BLOCK_NUM" 2> /dev/null
+
+banner "Recover Senders"
+time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/recover_senders recover-senders 0 "$BEDROCK_START_BLOCK_NUM" 2> /dev/null

--- a/migrate.sh
+++ b/migrate.sh
@@ -54,6 +54,8 @@ EXTRA_FLAGS="--no-downloader --nodiscover --maxpeers=0 --txpool.disable"
 EXTRA_FLAGS="$EXTRA_FLAGS --log.console.verbosity=3"
 EXTRA_FLAGS="$EXTRA_FLAGS --chain=$CHAIN"
 EXTRA_FLAGS="$EXTRA_FLAGS --metrics"
+# disable port collision between prometheus
+EXTRA_FLAGS="$EXTRA_FLAGS --private.api.addr=localhost:12345"
 
 banner "Import Genesis"
 time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/init_genesis init init/"$CHAIN".json 2> /dev/null

--- a/migrate.sh
+++ b/migrate.sh
@@ -53,6 +53,7 @@ fi
 EXTRA_FLAGS="--no-downloader --nodiscover --maxpeers=0 --txpool.disable"
 EXTRA_FLAGS="$EXTRA_FLAGS --log.console.verbosity=3"
 EXTRA_FLAGS="$EXTRA_FLAGS --chain=$CHAIN"
+EXTRA_FLAGS="$EXTRA_FLAGS --metrics"
 
 banner "Import Genesis"
 time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/init_genesis init init/"$CHAIN".json 2> /dev/null

--- a/migrate.sh
+++ b/migrate.sh
@@ -18,7 +18,6 @@ echo " |____/ \___|\__,_|_|  \___/ \___|_|\_\ |_|  |_|_|\__, |_|  \__,_|\__|_|\_
 echo "                                                   __/ |                            "
 echo "                                                  |___/                             "
 
-ERIGON_DATA_DIR="erigon_db"
 CHAIN="optimism-goerli"
 LOG_DIR="migration-log"
 
@@ -52,6 +51,12 @@ if [ ! -d "$ARTIFACT_PATH" ]; then
     exit 1
 fi
 echo "artifact path set to $ARTIFACT_PATH"
+
+ERIGON_DATA_DIR="erigon_db"
+if [[ -n "$4" ]]; then
+    ERIGON_DATA_DIR=$4
+fi
+echo "data dir set to $ERIGON_DATA_DIR"
 
 EXTRA_FLAGS="--no-downloader --nodiscover --maxpeers=0 --txpool.disable"
 EXTRA_FLAGS="$EXTRA_FLAGS --log.console.verbosity=3"

--- a/migrate.sh
+++ b/migrate.sh
@@ -53,7 +53,7 @@ fi
 EXTRA_FLAGS="--no-downloader --nodiscover --maxpeers=0 --txpool.disable"
 EXTRA_FLAGS="$EXTRA_FLAGS --log.console.verbosity=3"
 EXTRA_FLAGS="$EXTRA_FLAGS --chain=$CHAIN"
-EXTRA_FLAGS="$EXTRA_FLAGS --metrics"
+EXTRA_FLAGS="$EXTRA_FLAGS --metrics --metrics.addr=0.0.0.0 --metrics.port=55555"
 # disable port collision between prometheus
 EXTRA_FLAGS="$EXTRA_FLAGS --private.api.addr=localhost:12345"
 

--- a/migrate.sh
+++ b/migrate.sh
@@ -41,14 +41,17 @@ else
     exit 1
 fi
 
-if [ ! -d "$LOG_DIR" ]; then
-    mkdir "$LOG_DIR"
-fi
+mkdir -p "$LOG_DIR"
 
 ARTIFACT_PATH="/tmp/migration-artifact"
-if [ ! -d "$ARTIFACT_PATH" ]; then
-    mkdir "$ARTIFACT_PATH"
+if [[ -n "$3" ]]; then
+    ARTIFACT_PATH=$3
 fi
+if [ ! -d "$ARTIFACT_PATH" ]; then
+    echo "artifact path $ARTIFACT_PATH does not exist"
+    exit 1
+fi
+echo "artifact path set to $ARTIFACT_PATH"
 
 EXTRA_FLAGS="--no-downloader --nodiscover --maxpeers=0 --txpool.disable"
 EXTRA_FLAGS="$EXTRA_FLAGS --log.console.verbosity=3"

--- a/migrate_intermediatehash.sh
+++ b/migrate_intermediatehash.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+banner() {
+    echo "+------------------------------------------+"
+    printf "| %-40s |\n" "$(date)"
+    echo "|                                          |"
+    printf "|$(tput bold) %-40s $(tput sgr0)|\n" "$@"
+    echo "+------------------------------------------+"
+    slack_report "$1" > /dev/null
+}
+
+# never fail
+slack_report() {
+    if ! [ -e "slack_report.sh" ]; then
+        echo "slack reporter does not exist" 1>&2
+        return 0
+    fi
+    echo "sending slack message: $1"
+    ./slack_report.sh "$1" || true
+    echo
+}
+
+echo " ____           _                _      __  __ _                 _   _              "
+echo " |  _ \         | |              | |    |  \/  (_)               | | (_)            "
+echo " | |_) | ___  __| |_ __ ___   ___| | __ | \  / |_  __ _ _ __ __ _| |_ _  ___  _ __  "
+echo " |  _ < / _ \/ _  |  __/ _ \ / __| |/ / | |\/| | |/ _  | '__/ _  | __| |/ _ \| '_ \ "
+echo " | |_) |  __/ (_| | | | (_) | (__|   <  | |  | | | (_| | | | (_| | |_| | (_) | | | |"
+echo " |____/ \___|\__,_|_|  \___/ \___|_|\_\ |_|  |_|_|\__, |_|  \__,_|\__|_|\___/|_| |_|"
+echo "                                                   __/ |                            "
+echo "                                                  |___/                             "
+
+LOG_DIR="migration-log"
+
+mkdir -p "$LOG_DIR"
+
+ARTIFACT_PATH="/tmp/migration-artifact"
+if [[ -n "$1" ]]; then
+    ARTIFACT_PATH=$1
+fi
+if [ ! -d "$ARTIFACT_PATH" ]; then
+    echo "artifact path $ARTIFACT_PATH does not exist"
+    exit 1
+fi
+echo "artifact path set to $ARTIFACT_PATH"
+
+ERIGON_DATA_DIR="erigon_db"
+if [[ -n "$2" ]]; then
+    ERIGON_DATA_DIR=$2
+fi
+echo "data dir set to $ERIGON_DATA_DIR"
+
+EXTRA_FLAGS="--no-downloader --nodiscover --maxpeers=0 --txpool.disable"
+EXTRA_FLAGS="$EXTRA_FLAGS --log.console.verbosity=3"
+EXTRA_FLAGS="$EXTRA_FLAGS --chain=$CHAIN"
+EXTRA_FLAGS="$EXTRA_FLAGS --metrics --metrics.addr=0.0.0.0 --metrics.port=55555"
+# disable port collision between prometheus
+EXTRA_FLAGS="$EXTRA_FLAGS --private.api.addr=localhost:12345"
+
+banner "Recover Intermediate Hash"
+time ./build/bin/erigon $EXTRA_FLAGS --datadir=$ERIGON_DATA_DIR --log.dir.path=$LOG_DIR/recover_intermediatehash recover-intermediatehash $ARTIFACT_PATH/intermediatehash.bin 2> /dev/null
+
+slack_report "Recover done" > /dev/null

--- a/params/chainspecs/optimism-mainnet.json
+++ b/params/chainspecs/optimism-mainnet.json
@@ -15,12 +15,12 @@
     "arrowGlacierBlock": 3950000,
     "grayGlacierBlock": 3950000,
     "mergeNetsplitBlock": 3950000,
-    "bedrockBlock": 13371337,
+    "bedrockBlock": 105235063,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "optimism": {
-        "eip1559Elasticity": 10,
+        "eip1559Elasticity": 6,
         "eip1559Denominator": 50
     },
-    "regolithTime": 13371337
+    "regolithTime": 0
 }

--- a/params/config.go
+++ b/params/config.go
@@ -279,8 +279,12 @@ func ChainConfigByGenesisHash(genesisHash libcommon.Hash) *chain.Config {
 		return BorMainnetChainConfig
 	case genesisHash == BorDevnetGenesisHash:
 		return BorDevnetChainConfig
+	case genesisHash == OptimismMainnetGenesisHash:
+		return OptimismMainnetChainConfig
 	case genesisHash == OptimismGoerliGenesisHash:
 		return OptimismGoerliChainConfig
+	case genesisHash == OptimismDevnetGenesisHash:
+		return OptimismDevnetChainConfig
 	case genesisHash == GnosisGenesisHash:
 		return GnosisChainConfig
 	case genesisHash == ChiadoGenesisHash:

--- a/params/config.go
+++ b/params/config.go
@@ -65,8 +65,10 @@ var (
 )
 
 var (
-	GnosisGenesisStateRoot = libcommon.HexToHash("0x40cf4430ecaa733787d1a65154a3b9efb560c95d9e324a23b97f0609b539133b")
-	ChiadoGenesisStateRoot = libcommon.HexToHash("0x9ec3eaf4e6188dfbdd6ade76eaa88289b57c63c9a2cde8d35291d5a29e143d31")
+	GnosisGenesisStateRoot   = libcommon.HexToHash("0x40cf4430ecaa733787d1a65154a3b9efb560c95d9e324a23b97f0609b539133b")
+	ChiadoGenesisStateRoot   = libcommon.HexToHash("0x9ec3eaf4e6188dfbdd6ade76eaa88289b57c63c9a2cde8d35291d5a29e143d31")
+	OptimismMainnetStateRoot = libcommon.HexToHash("0xeddb4c1786789419153a27c4c80ff44a2226b6eda04f7e22ce5bae892ea568eb")
+	OptimismGoerliStateRoot  = libcommon.HexToHash("0x9e6b478a1cd331a979c39e4bddf42c676bcf5a63382f898dc441fe3fe5eb0837")
 )
 
 var (

--- a/turbo/app/db_sanity_check.go
+++ b/turbo/app/db_sanity_check.go
@@ -65,7 +65,7 @@ func dbSanityCheck(ctx *cli.Context) error {
 }
 
 func DbSanityCheck(ethereum *eth.Ethereum, blockNumber uint64, checkEmpty bool) error {
-	log.Info("Database sanity check for block number", "blockNumber", blockNumber)
+	log.Info("Database sanity check for block number", "blockNumber", blockNumber, "checkEmpty", checkEmpty)
 
 	startAddress := libcommon.Address{}
 

--- a/turbo/app/db_sanity_check.go
+++ b/turbo/app/db_sanity_check.go
@@ -1,0 +1,199 @@
+package app
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"time"
+
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/cmd/utils"
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/dbutils"
+	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/core/types/accounts"
+	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/eth"
+	turboNode "github.com/ledgerwatch/erigon/turbo/node"
+	"github.com/ledgerwatch/erigon/turbo/trie"
+	"github.com/ledgerwatch/log/v3"
+	"github.com/urfave/cli/v2"
+)
+
+var dbSanityCheckCommand = cli.Command{
+	Action:    MigrateFlags(dbSanityCheck),
+	Name:      "sanity-check",
+	Usage:     "sanity check blockchain database",
+	ArgsUsage: "<blockNum>",
+	Flags: []cli.Flag{
+		&utils.DataDirFlag,
+		&utils.ChainFlag,
+	},
+	Category: "BLOCKCHAIN COMMANDS",
+	Description: `
+The sanity check command checks database sanity`,
+}
+
+func dbSanityCheck(ctx *cli.Context) error {
+	if ctx.NArg() < 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+
+	nodeCfg := turboNode.NewNodConfigUrfave(ctx)
+	ethCfg := turboNode.NewEthConfigUrfave(ctx, nodeCfg)
+
+	stack := makeConfigNode(nodeCfg)
+	defer stack.Close()
+
+	ethereum, err := eth.New(stack, ethCfg)
+	if err != nil {
+		return err
+	}
+	blockNum, err := strconv.ParseInt(ctx.Args().First(), 10, 64)
+	if err != nil {
+		utils.Fatalf("Export error in parsing parameters: block number not an integer\n")
+	}
+
+	if err := DbSanityCheck(ethereum, uint64(blockNum)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func DbSanityCheck(ethereum *eth.Ethereum, blockNumber uint64) error {
+	log.Info("Database sanity check for block number", "blockNumber", blockNumber)
+
+	startAddress := libcommon.Address{}
+
+	db := ethereum.ChainDB()
+	tx, err := db.BeginRw(ethereum.SentryCtx())
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var acc accounts.Account
+	var accountList []*accounts.Account
+	var addrList []libcommon.Address
+	var incarnationList []uint64
+
+	idx := new(int)
+	quit := StatusReporter("Walk accounts", idx)
+	if err := state.WalkAsOfAccounts(tx,
+		startAddress,
+		blockNumber+1, /* do not know why adding one up, but it just works */
+		func(k, v []byte) (bool, error) {
+			*idx += 1
+			if len(k) > 32 {
+				return true, nil
+			}
+			if e := acc.DecodeForStorage(v); e != nil {
+				return false, fmt.Errorf("decoding %x for %x: %w", v, k, e)
+			}
+			// codehash and root will be filled at new loop
+			account := accounts.Account{
+				Nonce:    acc.Nonce,
+				Balance:  acc.Balance,
+				Root:     emptyHash,
+				CodeHash: emptyCodeHash,
+			}
+			accountList = append(accountList, &account)
+			addrList = append(addrList, libcommon.BytesToAddress(k))
+			incarnationList = append(incarnationList, acc.Incarnation)
+			return true, nil
+		}); err != nil {
+		return err
+	}
+	close(quit)
+
+	worldStateTrie := trie.New(emptyHash)
+
+	*idx = 0
+	quit = StatusReporter("Iterate accounts", idx)
+	for i, addr := range addrList {
+		*idx += 1
+		account := accountList[i]
+		genesisAccount := types.GenesisAccount{
+			Balance: account.Balance.ToBig(),
+			Nonce:   account.Nonce,
+		}
+		incarnation := incarnationList[i]
+		storagePrefix := dbutils.PlainGenerateStoragePrefix(addr[:], incarnation)
+		if incarnation > 0 {
+			codeHash, err := tx.GetOne(kv.PlainContractCode, storagePrefix)
+			if err != nil {
+				return fmt.Errorf("getting code hash for %x: %w", addr, err)
+			}
+			if codeHash != nil {
+				account.CodeHash = libcommon.BytesToHash(codeHash)
+			} else {
+				account.CodeHash = emptyCodeHash
+			}
+		} else {
+			account.CodeHash = emptyCodeHash
+		}
+		var code []byte
+		if !bytes.Equal(account.CodeHash.Bytes(), emptyCodeHash[:]) {
+			if code, err = tx.GetOne(kv.Code, account.CodeHash.Bytes()); err != nil {
+				return err
+			}
+			genesisAccount.Code = code
+		}
+		tempCodeHash := crypto.Keccak256(code)
+		if !bytes.Equal(tempCodeHash, account.CodeHash.Bytes()) {
+			return fmt.Errorf("codehash mismatch, expected %x, got %x", account.CodeHash.Bytes(), tempCodeHash)
+		}
+
+		storageTrie := trie.New(libcommon.Hash{})
+		if err := state.WalkAsOfStorage(tx,
+			addr,
+			incarnation,
+			libcommon.Hash{}, /* startLocation */
+			blockNumber+1,    /* do not know why adding one up, but it just works */
+			func(_, loc, vs []byte) (bool, error) {
+				h, _ := common.HashData(loc)
+				storageTrie.Update(h.Bytes(), libcommon.Copy(vs))
+				return true, nil
+			}); err != nil {
+			return fmt.Errorf("walking over storage for %x: %w", addr, err)
+		}
+		storageTrieRoot := storageTrie.Hash()
+		// storage trie root will be eventually checked by calculating world state trie root
+		account.Root = storageTrieRoot
+
+		value := make([]byte, account.EncodingLengthForHashing())
+		account.EncodeForHashing(value)
+
+		addrHash, _ := common.HashData(addr.Bytes())
+		worldStateTrie.UpdateAccount(addrHash.Bytes(), account)
+	}
+	close(quit)
+
+	startTime := time.Now()
+	stateRoot := worldStateTrie.Hash()
+	log.Info("World State Trie Root Calculation", "elapsed", time.Duration(time.Since(startTime)))
+	blockHash, err := rawdb.ReadCanonicalHash(tx, blockNumber)
+	if err != nil {
+		return err
+	}
+
+	header := rawdb.ReadHeader(tx, blockHash, blockNumber)
+	if header == nil {
+		return fmt.Errorf("header for block %d not found", blockNumber)
+	}
+
+	stateRootFromHeader := header.Root
+	log.Info("state root stored at blockheader", "root", stateRootFromHeader.Hex())
+
+	if bytes.Equal(stateRoot.Bytes(), stateRootFromHeader.Bytes()) {
+		log.Info("state root consistent with block header's state root")
+	} else {
+		return fmt.Errorf("state trie root mismatch, expected %x, got %x", stateRootFromHeader, stateRoot)
+	}
+
+	return nil
+}

--- a/turbo/app/db_sanity_check.go
+++ b/turbo/app/db_sanity_check.go
@@ -175,7 +175,7 @@ func DbSanityCheck(ethereum *eth.Ethereum, blockNumber uint64, checkEmpty bool) 
 
 	startTime := time.Now()
 	stateRoot := worldStateTrie.Hash()
-	log.Info("World State Trie Root Calculation", "elapsed", time.Duration(time.Since(startTime)))
+	log.Info("World State Trie Root Calculation", "elapsed", time.Since(startTime))
 
 	var targetRoot libcommon.Hash
 	if checkEmpty {

--- a/turbo/app/drop.go
+++ b/turbo/app/drop.go
@@ -42,7 +42,7 @@ func dropLogIndex(ctx *cli.Context) error {
 	if err := DropLogIndex(ethereum); err != nil {
 		return err
 	}
-	
+
 	return nil
 }
 

--- a/turbo/app/drop.go
+++ b/turbo/app/drop.go
@@ -1,0 +1,72 @@
+package app
+
+import (
+	"time"
+
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/cmd/utils"
+	"github.com/ledgerwatch/erigon/eth"
+	turboNode "github.com/ledgerwatch/erigon/turbo/node"
+	"github.com/ledgerwatch/log/v3"
+	"github.com/urfave/cli/v2"
+)
+
+var dropLogIndexCommand = cli.Command{
+	Action: MigrateFlags(dropLogIndex),
+	Name:   "drop-log-index",
+	Usage:  "drop log index",
+	Flags: []cli.Flag{
+		&utils.DataDirFlag,
+		&utils.ChainFlag,
+	},
+	Category: "BLOCKCHAIN COMMANDS",
+	Description: `
+The drop command drops LogTopicIndex table and LogAddressIndex table.`,
+}
+
+func dropLogIndex(ctx *cli.Context) error {
+	nodeCfg := turboNode.NewNodConfigUrfave(ctx)
+	ethCfg := turboNode.NewEthConfigUrfave(ctx, nodeCfg)
+
+	stack := makeConfigNode(nodeCfg)
+	defer stack.Close()
+
+	ethereum, err := eth.New(stack, ethCfg)
+	if err != nil {
+		return err
+	}
+	err = ethereum.Init(stack, ethCfg)
+	if err != nil {
+		return err
+	}
+	if err := DropLogIndex(ethereum); err != nil {
+		return err
+	}
+	
+	return nil
+}
+
+func DropLogIndex(ethereum *eth.Ethereum) error {
+	log.Info("Dropping Log Index")
+	db := ethereum.ChainDB()
+	tx, err := db.BeginRw(ethereum.SentryCtx())
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	startTime := time.Now()
+	if err := tx.ClearBucket(kv.LogTopicIndex); err != nil {
+		return err
+	}
+	log.Info("Dropped LogTopicIndex Table", "elapsed", time.Duration(time.Since(startTime)))
+	if err := tx.ClearBucket(kv.LogAddressIndex); err != nil {
+		return err
+	}
+	log.Info("Dropped LogAddressIndex Table", "elapsed", time.Duration(time.Since(startTime)))
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	log.Info("DB commit", "elapsed", time.Duration(time.Since(startTime)))
+	return nil
+}

--- a/turbo/app/import.go
+++ b/turbo/app/import.go
@@ -830,6 +830,7 @@ func ImportState(ethereum *eth.Ethereum, fn string, blockNumber uint64, stream b
 		for address, account := range ia {
 			idx += 1
 			account.Address = address
+			//nolint:all
 			if err := storeAccount(statedb, &account); err != nil {
 				return err
 			}
@@ -953,6 +954,7 @@ func SanityCheckStorageTrie(ethereum *eth.Ethereum, fn string, blockNumber uint6
 		for address, account := range ia {
 			idx += 1
 			account.Address = address
+			//nolint:all
 			if err := sanityCheckStorageTrie(statedb, tx, &account, blockNumber); err != nil {
 				return err
 			}

--- a/turbo/app/import.go
+++ b/turbo/app/import.go
@@ -299,7 +299,9 @@ func InsertChainWithoutExecution(ethereum *eth.Ethereum, chain *core.ChainPack) 
 		if i == 0 {
 			log.Info("Write", "blockNum", block.Number().String())
 		}
-		WriteBlockWithoutExecution(ethereum, tx, block)
+		if err := WriteBlockWithoutExecution(ethereum, tx, block); err != nil {
+			return err
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return err

--- a/turbo/app/import.go
+++ b/turbo/app/import.go
@@ -867,12 +867,12 @@ func SanityCheckStorageTrie(ethereum *eth.Ethereum, fn string, blockNumber uint6
 	for address, account := range ia {
 		idx += 1
 		incarnation := statedb.GetIncarnation(address)
-		newStorageTrie := trie.New(libcommon.Hash{})
+		newStorageTrie := trie.New(emptyHash)
 		if err := state.WalkAsOfStorage(tx,
 			address,
 			incarnation,
-			libcommon.Hash{}, /* startLocation */
-			blockNumber+1,    /* do not know why adding one up, but it just works */
+			emptyHash,     /* startLocation */
+			blockNumber+1, /* do not know why adding one up, but it just works */
 			func(_, loc, vs []byte) (bool, error) {
 				h, _ := common.HashData(loc)
 				newStorageTrie.Update(h.Bytes(), common.CopyBytes(vs))

--- a/turbo/app/import.go
+++ b/turbo/app/import.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"os/signal"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/ledgerwatch/log/v3"
 	"github.com/urfave/cli/v2"
 
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/rawdb"
@@ -46,6 +48,20 @@ with several RLP-encoded blocks, or several files can be used.
 
 If only one file is used, import error will result in failure. If several files are used,
 processing will proceed even if an individual RLP-file import failure occurs.`,
+}
+
+var importReceiptCommand = cli.Command{
+	Action:    MigrateFlags(importReceipts),
+	Name:      "import-receipts",
+	Usage:     "Import a receipts file",
+	ArgsUsage: "<filename> ",
+	Flags: []cli.Flag{
+		&utils.DataDirFlag,
+		&utils.ChainFlag,
+	},
+	Category: "BLOCKCHAIN COMMANDS",
+	Description: `
+The import command imports receipts from an RLP-encoded form.`,
 }
 
 func importChain(ctx *cli.Context) error {
@@ -184,6 +200,17 @@ func ChainHasBlock(chainDB kv.RwDB, block *types.Block) bool {
 	return chainHasBlock
 }
 
+func ChainHasReceipt(chainDB kv.RwDB, hash libcommon.Hash, number uint64) bool {
+	var chainHasReceipt bool
+
+	chainDB.View(context.Background(), func(tx kv.Tx) (err error) {
+		chainHasReceipt = rawdb.HasReceipts(tx, hash, number)
+		return nil
+	})
+
+	return chainHasReceipt
+}
+
 func missingBlocks(chainDB kv.RwDB, blocks []*types.Block) []*types.Block {
 	var headBlock *types.Block
 	chainDB.View(context.Background(), func(tx kv.Tx) (err error) {
@@ -207,6 +234,36 @@ func missingBlocks(chainDB kv.RwDB, blocks []*types.Block) []*types.Block {
 		}
 	}
 
+	return nil
+}
+
+func missingReceiptsList(chainDB kv.RwDB, receiptsList []*types.Receipts) []*types.Receipts {
+	var headBlock *types.Block
+	chainDB.View(context.Background(), func(tx kv.Tx) (err error) {
+		hash := rawdb.ReadHeadHeaderHash(tx)
+		number := rawdb.ReadHeaderNumber(tx, hash)
+		headBlock = rawdb.ReadBlock(tx, hash, *number)
+		return nil
+	})
+
+	for i, receipts := range receiptsList {
+		if receipts.Len() == 0 {
+			continue
+		}
+		firstReceipt := []*types.Receipt(*receipts)[0]
+		blockHash := firstReceipt.BlockHash
+		blockNumber := firstReceipt.BlockNumber.Uint64()
+		if headBlock.NumberU64() >= blockNumber {
+			if !ChainHasReceipt(chainDB, blockHash, blockNumber) {
+				return receiptsList[i:]
+			}
+			continue
+		}
+
+		if !ChainHasReceipt(chainDB, blockHash, blockNumber) {
+			return receiptsList[i:]
+		}
+	}
 	return nil
 }
 
@@ -281,6 +338,175 @@ func WriteBlockWithoutExecution(ethereum *eth.Ethereum, tx kv.RwTx, block *types
 	txHash := types.DeriveSha(block.Transactions())
 	if txHash != block.TxHash() {
 		return errors.New("tx trie root mismatch. aborting")
+	}
+
+	return nil
+}
+
+func importReceipts(ctx *cli.Context) error {
+	if ctx.NArg() < 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+
+	nodeCfg := turboNode.NewNodConfigUrfave(ctx)
+	ethCfg := turboNode.NewEthConfigUrfave(ctx, nodeCfg)
+
+	stack := makeConfigNode(nodeCfg)
+	defer stack.Close()
+
+	ethereum, err := eth.New(stack, ethCfg)
+	if err != nil {
+		return err
+	}
+
+	if err := ImportReceipts(ethereum, ethereum.ChainDB(), ctx.Args().First()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ImportReceipts(ethereum *eth.Ethereum, chainDB kv.RwDB, fn string) error {
+	// Watch for Ctrl-C while the import is running.
+	// If a signal is received, the import will stop at the next batch.
+	interrupt := make(chan os.Signal, 1)
+	stop := make(chan struct{})
+	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(interrupt)
+	defer close(interrupt)
+	go func() {
+		if _, ok := <-interrupt; ok {
+			log.Info("Interrupted during import, stopping at next batch")
+		}
+		close(stop)
+	}()
+	checkInterrupt := func() bool {
+		select {
+		case <-stop:
+			return true
+		default:
+			return false
+		}
+	}
+
+	log.Info("Importing receipts", "file", fn)
+
+	// Open the file handle and potentially unwrap the gzip stream
+	fh, err := os.Open(fn)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	var reader io.Reader = fh
+	if strings.HasSuffix(fn, ".gz") {
+		if reader, err = gzip.NewReader(reader); err != nil {
+			return err
+		}
+	}
+	stream := rlp.NewStream(reader, 0)
+
+	// Run actual the import.
+	receiptsList := make(types.ReceiptsList, importBatchSize)
+	n := 0
+	for batch := 0; ; batch++ {
+		// Load a batch of RLP blocks.
+		if checkInterrupt() {
+			return fmt.Errorf("interrupted")
+		}
+		i := 0
+		for ; i < importBatchSize; i++ {
+			var hackreceipts types.HackReceipts
+			if err := stream.Decode(&hackreceipts); errors.Is(err, io.EOF) {
+				break
+			} else if err != nil {
+				return fmt.Errorf("at block %d: %v", n, err)
+			}
+
+			// hack assuming that default rlp will work
+			var receipts types.Receipts
+			for _, hackReceipt := range hackreceipts {
+				feeScalar := new(big.Float)
+				feeScalar.SetString(hackReceipt.FeeScalar)
+				receipt := types.Receipt{
+					Type:              hackReceipt.Type,
+					PostState:         hackReceipt.PostState,
+					Status:            hackReceipt.Status,
+					CumulativeGasUsed: hackReceipt.CumulativeGasUsed,
+					Bloom:             hackReceipt.Bloom,
+					Logs:              hackReceipt.Logs,
+					TxHash:            hackReceipt.TxHash,
+					ContractAddress:   hackReceipt.ContractAddress,
+					GasUsed:           hackReceipt.GasUsed,
+					BlockHash:         hackReceipt.BlockHash,
+					BlockNumber:       hackReceipt.BlockNumber,
+					TransactionIndex:  hackReceipt.TransactionIndex,
+					L1GasPrice:        hackReceipt.L1GasPrice,
+					L1GasUsed:         hackReceipt.L1GasUsed,
+					L1Fee:             hackReceipt.L1Fee,
+					FeeScalar:         feeScalar,
+					// no depositnonce before bedrock
+					DepositNonce: nil,
+				}
+				receipts = append(receipts, &receipt)
+			}
+			receiptsList[i] = &receipts
+			n++
+		}
+		if i == 0 {
+			break
+		}
+		// Import the batch.
+		if checkInterrupt() {
+			return fmt.Errorf("interrupted")
+		}
+
+		missing := missingReceiptsList(chainDB, receiptsList[:i])
+		if len(missing) == 0 {
+			log.Info("Skipping batch as all receipts present", "batch", batch)
+			continue
+		}
+
+		if err := InsertReceipts(ethereum, missing); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func InsertReceipts(ethereum *eth.Ethereum, receiptsList []*types.Receipts) error {
+	db := ethereum.ChainDB()
+	tx, err := db.BeginRw(ethereum.SentryCtx())
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	for _, receipts := range receiptsList {
+		if receipts.Len() == 0 {
+			continue
+		}
+		firstReceipt := []*types.Receipt(*receipts)[0]
+		blockNumber := firstReceipt.BlockNumber.Uint64()
+		// log.Info("Write receipt", "block", blockNumber)
+		block := rawdb.ReadBlock(tx, firstReceipt.BlockHash, blockNumber)
+
+		var receiptsVal types.Receipts = *receipts
+		err = rawdb.WriteReceipts(tx, blockNumber, receiptsVal)
+		if err != nil {
+			log.Error(err.Error())
+			break
+		}
+
+		receiptHash := types.DeriveSha(receipts)
+		if receiptHash != block.ReceiptHash() {
+			return errors.New("receipt trie root mismatch. aborting")
+		}
+
+	}
+	if err := tx.Commit(); err != nil {
+		return err
 	}
 
 	return nil

--- a/turbo/app/import.go
+++ b/turbo/app/import.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon-lib/chain"
@@ -803,16 +804,20 @@ func ImportState(ethereum *eth.Ethereum, fn string, blockNumber uint64) error {
 	}
 	log.Info("newly calculated root", "root", root.Hex())
 
+	startTime := time.Now()
 	blockWriter := state.NewPlainStateWriter(tx, tx, blockNumber)
 	if err := statedb.CommitBlock(&chain.Rules{}, blockWriter); err != nil {
 		return fmt.Errorf("cannot write state: %w", err)
 	}
+	log.Info("commit block", "elapsed", time.Duration(time.Since(startTime)))
 	if err := blockWriter.WriteChangeSets(); err != nil {
 		return fmt.Errorf("cannot write change sets: %w", err)
 	}
+	log.Info("write change sets", "elapsed", time.Duration(time.Since(startTime)))
 	if err := blockWriter.WriteHistory(); err != nil {
 		return fmt.Errorf("cannot write history: %w", err)
 	}
+	log.Info("write history", "elapsed", time.Duration(time.Since(startTime)))
 
 	blockHash, err := rawdb.ReadCanonicalHash(tx, blockNumber)
 	if err != nil {

--- a/turbo/app/import.go
+++ b/turbo/app/import.go
@@ -340,9 +340,6 @@ func InsertChainWithoutExecution(ethereum *eth.Ethereum, chain *core.ChainPack) 
 
 	for i := 0; i < chain.Length(); i++ {
 		block := chain.Blocks[i]
-		if i == 0 {
-			log.Info("Write", "blockNum", block.Number().String())
-		}
 		if err := WriteBlockWithoutExecution(ethereum, tx, block); err != nil {
 			return err
 		}
@@ -570,7 +567,6 @@ func InsertReceipts(ethereum *eth.Ethereum, receiptsList []*types.Receipts) erro
 		}
 		firstReceipt := []*types.Receipt(*receipts)[0]
 		blockNumber := firstReceipt.BlockNumber.Uint64()
-		// log.Info("Write receipt", "block", blockNumber)
 		block := rawdb.ReadBlock(tx, firstReceipt.BlockHash, blockNumber)
 
 		var receiptsVal types.Receipts = *receipts

--- a/turbo/app/import.go
+++ b/turbo/app/import.go
@@ -461,9 +461,10 @@ func importState(ctx *cli.Context) error {
 	if err := ImportState(ethereum, fn, uint64(blockNum), ethCfg.ImportStateStream); err != nil {
 		return err
 	}
-	if err := SanityCheckStorageTrie(ethereum, fn, uint64(blockNum), ethCfg.ImportStateStream); err != nil {
-		return err
-	}
+	// storage trie sanity check will manually done using sanity-check command
+	// if err := SanityCheckStorageTrie(ethereum, fn, uint64(blockNum), ethCfg.ImportStateStream); err != nil {
+	// 	return err
+	// }
 
 	return nil
 }

--- a/turbo/app/import.go
+++ b/turbo/app/import.go
@@ -453,10 +453,10 @@ func importState(ctx *cli.Context) error {
 		utils.Fatalf("Export error in parsing parameters: block number not an integer\n")
 	}
 
-	if err := SanityCheckStorageTrie(ethereum, fn, uint64(blockNum)); err != nil {
+	if err := ImportState(ethereum, fn, uint64(blockNum)); err != nil {
 		return err
 	}
-	if err := ImportState(ethereum, fn, uint64(blockNum)); err != nil {
+	if err := SanityCheckStorageTrie(ethereum, fn, uint64(blockNum)); err != nil {
 		return err
 	}
 

--- a/turbo/app/import.go
+++ b/turbo/app/import.go
@@ -452,6 +452,10 @@ func importState(ctx *cli.Context) error {
 		utils.Fatalf("Export error in parsing parameters: block number not an integer\n")
 	}
 
+	// make sure state trie is empty before import
+	if err := DbSanityCheck(ethereum, uint64(blockNum), true); err != nil {
+		return err
+	}
 	if err := ImportState(ethereum, fn, uint64(blockNum)); err != nil {
 		return err
 	}

--- a/turbo/app/import.go
+++ b/turbo/app/import.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -457,13 +458,21 @@ func importState(ctx *cli.Context) error {
 	if err := DbSanityCheck(ethereum, uint64(blockNum), true); err != nil {
 		return err
 	}
-	if err := ImportState(ethereum, fn, uint64(blockNum)); err != nil {
-		return err
+	if ethCfg.ImportStateStream {
+		if err := ImportStateStream(ethereum, fn, uint64(blockNum)); err != nil {
+			return err
+		}
+		if err := SanityCheckStorageTrieStream(ethereum, fn, uint64(blockNum)); err != nil {
+			return err
+		}
+	} else {
+		if err := ImportState(ethereum, fn, uint64(blockNum)); err != nil {
+			return err
+		}
+		if err := SanityCheckStorageTrie(ethereum, fn, uint64(blockNum)); err != nil {
+			return err
+		}
 	}
-	if err := SanityCheckStorageTrie(ethereum, fn, uint64(blockNum)); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -705,9 +714,14 @@ type ImportAccount struct {
 	CodeHash string                    `json:"codeHash"`
 	Code     string                    `json:"code,omitempty"`
 	Storage  map[libcommon.Hash]string `json:"storage,omitempty"`
+	Address  libcommon.Address         `json:"address,omitempty"`
 }
 
 type ImportAlloc map[libcommon.Address]ImportAccount
+
+type ImportStreamHeader struct {
+	Root libcommon.Hash `json:"root"`
+}
 
 func (ia *ImportAlloc) UnmarshalJson(data []byte) error {
 	m := make(ImportAlloc)
@@ -721,6 +735,146 @@ func (ia *ImportAlloc) UnmarshalJson(data []byte) error {
 	return nil
 }
 
+func ImportStateStream(ethereum *eth.Ethereum, fn string, blockNumber uint64) error {
+	log.Info("Importing state as stream", "file", fn)
+	log.Info("Importing state as stream for block number", "blockNumber", blockNumber)
+	fh, err := os.Open(fn)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	db := ethereum.ChainDB()
+	tx, err := db.BeginRw(ethereum.SentryCtx())
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	r, w := state.NewDbStateReader(tx), state.NewDbStateWriter(tx, blockNumber)
+	statedb := state.New(r)
+
+	reader := bufio.NewReader(fh)
+	delimiter := byte('\n')
+	var importStreamHeader ImportStreamHeader
+
+	idx := 0
+	quit := StatusReporter("Import state as stream", &idx)
+
+	headerConsumed := false
+	for {
+		line, err := reader.ReadBytes(delimiter)
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return err
+		}
+		if !headerConsumed {
+			if err := json.Unmarshal(line, &importStreamHeader); err != nil {
+				return err
+			}
+			log.Info("state root from header", "root", importStreamHeader.Root.Hex())
+			headerConsumed = true
+			continue
+		}
+		var account ImportAccount
+		if err := json.Unmarshal(line, &account); err != nil {
+			return err
+		}
+		idx += 1
+		address := account.Address
+		balanceBigInt, ok := new(big.Int).SetString(account.Balance, 10)
+		if !ok {
+			return errors.New("balance bigint conversion failure")
+		}
+		balance, overflow := uint256.FromBig(balanceBigInt)
+		if overflow {
+			return errors.New("balance overflow")
+		}
+		statedb.AddBalance(address, balance)
+		hexCode := strings.TrimPrefix(account.Code, "0x")
+		code, err := hex.DecodeString(hexCode)
+		if err != nil {
+			return fmt.Errorf("code hexdecode failure, %s", hexCode)
+		}
+		hexCodeHash := strings.TrimPrefix(account.CodeHash, "0x")
+		codeHash, err := hex.DecodeString(hexCodeHash)
+		if err != nil {
+			return fmt.Errorf("codehash hexdecode failure, %s", hexCodeHash)
+		}
+		tempCodeHash := crypto.Keccak256(code)
+		if !bytes.Equal(tempCodeHash, codeHash) {
+			return fmt.Errorf("codehash mismatch, expected %x, got %x", codeHash, tempCodeHash)
+		}
+		statedb.SetCode(address, code)
+		statedb.SetNonce(address, account.Nonce)
+		for key, hexValue := range account.Storage {
+			key := key
+			value, err := hex.DecodeString(hexValue)
+			if err != nil {
+				return errors.New("value hexdecode failure")
+			}
+			val := uint256.NewInt(0).SetBytes(value)
+			statedb.SetState(address, &key, *val)
+		}
+
+		if len(account.Code) > 0 || len(account.Storage) > 0 {
+			statedb.SetIncarnation(address, state.FirstContractIncarnation)
+		}
+	}
+	close(quit)
+
+	if err := statedb.FinalizeTx(&chain.Rules{}, w); err != nil {
+		return err
+	}
+
+	root, err := trie.CalcRoot("regenesis", tx)
+	if err != nil {
+		log.Info("root calculation failed")
+		return err
+	}
+	log.Info("newly calculated root", "root", root.Hex())
+
+	startTime := time.Now()
+	blockWriter := state.NewPlainStateWriter(tx, tx, blockNumber)
+	if err := statedb.CommitBlock(&chain.Rules{}, blockWriter); err != nil {
+		return fmt.Errorf("cannot write state: %w", err)
+	}
+	log.Info("commit block", "elapsed", time.Duration(time.Since(startTime)))
+	if err := blockWriter.WriteChangeSets(); err != nil {
+		return fmt.Errorf("cannot write change sets: %w", err)
+	}
+	log.Info("write change sets", "elapsed", time.Duration(time.Since(startTime)))
+	if err := blockWriter.WriteHistory(); err != nil {
+		return fmt.Errorf("cannot write history: %w", err)
+	}
+	log.Info("write history", "elapsed", time.Duration(time.Since(startTime)))
+
+	blockHash, err := rawdb.ReadCanonicalHash(tx, blockNumber)
+	if err != nil {
+		return err
+	}
+
+	header := rawdb.ReadHeader(tx, blockHash, blockNumber)
+	log.Info("state root stored at blockheader", "root", header.Root.Hex())
+
+	if bytes.Equal(root.Bytes(), header.Root.Bytes()) {
+		log.Info("state root consistent with block header's state root")
+	} else {
+		return fmt.Errorf("state trie root mismatch, expected %x, got %x", header.Root, root)
+	}
+
+	// first bedrock block does not have tx, so no tx receipt
+	if err != rawdb.WriteReceipts(tx, blockNumber, nil) {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func ImportState(ethereum *eth.Ethereum, fn string, blockNumber uint64) error {
 	log.Info("Importing state", "file", fn)
 	log.Info("Importing state for block number", "blockNumber", blockNumber)
@@ -728,8 +882,8 @@ func ImportState(ethereum *eth.Ethereum, fn string, blockNumber uint64) error {
 	if err != nil {
 		return err
 	}
+	defer fh.Close()
 
-	// TODO: make as jsonl stream
 	decoder := json.NewDecoder(fh)
 	ia := make(ImportAlloc)
 
@@ -761,12 +915,12 @@ func ImportState(ethereum *eth.Ethereum, fn string, blockNumber uint64) error {
 			return errors.New("balance overflow")
 		}
 		statedb.AddBalance(address, balance)
-		hexCode := account.Code
+		hexCode := strings.TrimPrefix(account.Code, "0x")
 		code, err := hex.DecodeString(hexCode)
 		if err != nil {
 			return fmt.Errorf("code hexdecode failure, %s", hexCode)
 		}
-		hexCodeHash := account.CodeHash
+		hexCodeHash := strings.TrimPrefix(account.CodeHash, "0x")
 		codeHash, err := hex.DecodeString(hexCodeHash)
 		if err != nil {
 			return fmt.Errorf("codehash hexdecode failure, %s", hexCodeHash)
@@ -851,8 +1005,8 @@ func SanityCheckStorageTrie(ethereum *eth.Ethereum, fn string, blockNumber uint6
 	if err != nil {
 		return err
 	}
+	defer fh.Close()
 
-	// TODO: make as jsonl stream
 	decoder := json.NewDecoder(fh)
 	ia := make(ImportAlloc)
 
@@ -890,7 +1044,85 @@ func SanityCheckStorageTrie(ethereum *eth.Ethereum, fn string, blockNumber uint6
 			return fmt.Errorf("walking over storage for %x: %w", address, err)
 		}
 		newStorageTrieRoot := newStorageTrie.Root()
-		hexStorageRoot := account.Root
+		hexStorageRoot := strings.TrimPrefix(account.Root, "0x")
+		storageRoot, err := hex.DecodeString(hexStorageRoot)
+
+		if err != nil {
+			return errors.New("storage root hexdecode failure")
+		}
+		if !bytes.Equal(newStorageTrieRoot, storageRoot) {
+			return fmt.Errorf("storage root mismatch, expected %x, got %x", newStorageTrieRoot, storageRoot)
+		}
+	}
+	close(quit)
+
+	return nil
+}
+
+func SanityCheckStorageTrieStream(ethereum *eth.Ethereum, fn string, blockNumber uint64) error {
+	log.Info("Sanity check storage trie stream", "file", fn)
+	log.Info("Sanity check storage trie stream for block number", "blockNumber", blockNumber)
+	fh, err := os.Open(fn)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	db := ethereum.ChainDB()
+	tx, err := db.BeginRw(ethereum.SentryCtx())
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	r := state.NewDbStateReader(tx)
+	statedb := state.New(r)
+
+	reader := bufio.NewReader(fh)
+	delimiter := byte('\n')
+	var importStreamHeader ImportStreamHeader
+
+	idx := 0
+	quit := StatusReporter("Sanity check storage trie using stream", &idx)
+
+	headerConsumed := false
+	for {
+		line, err := reader.ReadBytes(delimiter)
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return err
+		}
+		if !headerConsumed {
+			if err := json.Unmarshal(line, &importStreamHeader); err != nil {
+				return err
+			}
+			log.Info("state root from header", "root", importStreamHeader.Root.Hex())
+			headerConsumed = true
+			continue
+		}
+		var account ImportAccount
+		if err := json.Unmarshal(line, &account); err != nil {
+			return err
+		}
+		idx += 1
+		address := account.Address
+		incarnation := statedb.GetIncarnation(address)
+		newStorageTrie := trie.New(emptyHash)
+		if err := state.WalkAsOfStorage(tx,
+			address,
+			incarnation,
+			emptyHash,     /* startLocation */
+			blockNumber+1, /* do not know why adding one up, but it just works */
+			func(_, loc, vs []byte) (bool, error) {
+				h, _ := common.HashData(loc)
+				newStorageTrie.Update(h.Bytes(), common.CopyBytes(vs))
+				return true, nil
+			}); err != nil {
+			return fmt.Errorf("walking over storage for %x: %w", address, err)
+		}
+		newStorageTrieRoot := newStorageTrie.Root()
+		hexStorageRoot := strings.TrimPrefix(account.Root, "0x")
 		storageRoot, err := hex.DecodeString(hexStorageRoot)
 
 		if err != nil {

--- a/turbo/app/import.go
+++ b/turbo/app/import.go
@@ -15,7 +15,6 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon-lib/chain"
@@ -175,7 +174,7 @@ func ImportChain(ethereum *eth.Ethereum, chainDB kv.RwDB, fn string, execute boo
 	blocks := make(types.Blocks, importBatchSize)
 
 	n := 0
-	quit := statusReporter("Import blockchain", &n)
+	quit := StatusReporter("Import blockchain", &n)
 
 	for batch := 0; ; batch++ {
 		// Load a batch of RLP blocks.
@@ -507,7 +506,7 @@ func ImportReceipts(ethereum *eth.Ethereum, chainDB kv.RwDB, fn string) error {
 	receiptsList := make(types.ReceiptsList, importBatchSize)
 
 	n := 0
-	quit := statusReporter("Import receipts", &n)
+	quit := StatusReporter("Import receipts", &n)
 
 	for batch := 0; ; batch++ {
 		// Load a batch of RLP blocks.
@@ -630,7 +629,7 @@ func ImportTotalDifficulty(ethereum *eth.Ethereum, chainDB kv.RwDB, fn string) e
 	stream := rlp.NewStream(reader, 0)
 
 	n := 0
-	quit := statusReporter("Import total difficulty", &n)
+	quit := StatusReporter("Import total difficulty", &n)
 
 	startNum := 0
 	for batch := 0; ; batch++ {
@@ -744,7 +743,7 @@ func ImportState(ethereum *eth.Ethereum, fn string, blockNumber uint64) error {
 	statedb := state.New(r)
 
 	idx := 0
-	quit := statusReporter("Import state", &idx)
+	quit := StatusReporter("Import state", &idx)
 
 	for address, account := range ia {
 		idx += 1
@@ -863,7 +862,7 @@ func SanityCheckStorageTrie(ethereum *eth.Ethereum, fn string, blockNumber uint6
 	statedb := state.New(r)
 
 	idx := 0
-	quit := statusReporter("Sanity check storage trie", &idx)
+	quit := StatusReporter("Sanity check storage trie", &idx)
 
 	for address, account := range ia {
 		idx += 1
@@ -895,25 +894,4 @@ func SanityCheckStorageTrie(ethereum *eth.Ethereum, fn string, blockNumber uint6
 	close(quit)
 
 	return nil
-}
-
-func statusReporter(msg string, idx *int) chan struct{} {
-	startTime := time.Now()
-	ticker := time.NewTicker(8 * time.Second)
-	quit := make(chan struct{})
-
-	go func(index *int) {
-		for {
-			select {
-			case <-ticker.C:
-				log.Info(msg, "index", *index, "elapsed", time.Duration(time.Since(startTime)))
-			case <-quit:
-				log.Info(msg, "index", *index, "elapsed", time.Duration(time.Since(startTime)))
-				ticker.Stop()
-				return
-			}
-		}
-	}(idx)
-
-	return quit
 }

--- a/turbo/app/make_app.go
+++ b/turbo/app/make_app.go
@@ -31,7 +31,9 @@ func MakeApp(action cli.ActionFunc, cliFlags []cli.Flag) *cli.App {
 		debug.Exit()
 		return nil
 	}
-	app.Commands = []*cli.Command{&initCommand, &importCommand, &snapshotCommand, &supportCommand}
+	app.Commands = []*cli.Command{&initCommand,
+		&importCommand, &importReceiptCommand,
+		&snapshotCommand, &supportCommand}
 	return app
 }
 

--- a/turbo/app/make_app.go
+++ b/turbo/app/make_app.go
@@ -33,7 +33,7 @@ func MakeApp(action cli.ActionFunc, cliFlags []cli.Flag) *cli.App {
 	}
 	app.Commands = []*cli.Command{&initCommand,
 		&importCommand, &importReceiptCommand, &importTotalDifficultyCommand, &importStateCommand,
-		&recoverSendersCommand,
+		&recoverSendersCommand, &recoverLogIndexCommand,
 		&snapshotCommand, &supportCommand}
 	return app
 }

--- a/turbo/app/make_app.go
+++ b/turbo/app/make_app.go
@@ -33,7 +33,7 @@ func MakeApp(action cli.ActionFunc, cliFlags []cli.Flag) *cli.App {
 	}
 	app.Commands = []*cli.Command{&initCommand,
 		&importCommand, &importReceiptCommand, &importTotalDifficultyCommand, &importStateCommand,
-		&recoverSendersCommand, &recoverLogIndexCommand, &recoverRegenesisCommand,
+		&recoverSendersCommand, &recoverLogIndexCommand, &recoverRegenesisCommand, &recoverIntermediateHashCommand,
 		&dropLogIndexCommand,
 		&dbSanityCheckCommand,
 		&snapshotCommand, &supportCommand}

--- a/turbo/app/make_app.go
+++ b/turbo/app/make_app.go
@@ -32,7 +32,7 @@ func MakeApp(action cli.ActionFunc, cliFlags []cli.Flag) *cli.App {
 		return nil
 	}
 	app.Commands = []*cli.Command{&initCommand,
-		&importCommand, &importReceiptCommand,
+		&importCommand, &importReceiptCommand, &importTotalDifficultyCommand,
 		&snapshotCommand, &supportCommand}
 	return app
 }

--- a/turbo/app/make_app.go
+++ b/turbo/app/make_app.go
@@ -33,6 +33,7 @@ func MakeApp(action cli.ActionFunc, cliFlags []cli.Flag) *cli.App {
 	}
 	app.Commands = []*cli.Command{&initCommand,
 		&importCommand, &importReceiptCommand, &importTotalDifficultyCommand, &importStateCommand,
+		&recoverSendersCommand,
 		&snapshotCommand, &supportCommand}
 	return app
 }

--- a/turbo/app/make_app.go
+++ b/turbo/app/make_app.go
@@ -35,6 +35,7 @@ func MakeApp(action cli.ActionFunc, cliFlags []cli.Flag) *cli.App {
 		&importCommand, &importReceiptCommand, &importTotalDifficultyCommand, &importStateCommand,
 		&recoverSendersCommand, &recoverLogIndexCommand,
 		&dropLogIndexCommand,
+		&dbSanityCheckCommand,
 		&snapshotCommand, &supportCommand}
 	return app
 }

--- a/turbo/app/make_app.go
+++ b/turbo/app/make_app.go
@@ -33,7 +33,7 @@ func MakeApp(action cli.ActionFunc, cliFlags []cli.Flag) *cli.App {
 	}
 	app.Commands = []*cli.Command{&initCommand,
 		&importCommand, &importReceiptCommand, &importTotalDifficultyCommand, &importStateCommand,
-		&recoverSendersCommand, &recoverLogIndexCommand,
+		&recoverSendersCommand, &recoverLogIndexCommand, &recoverRegenesisCommand,
 		&dropLogIndexCommand,
 		&dbSanityCheckCommand,
 		&snapshotCommand, &supportCommand}

--- a/turbo/app/make_app.go
+++ b/turbo/app/make_app.go
@@ -32,7 +32,7 @@ func MakeApp(action cli.ActionFunc, cliFlags []cli.Flag) *cli.App {
 		return nil
 	}
 	app.Commands = []*cli.Command{&initCommand,
-		&importCommand, &importReceiptCommand, &importTotalDifficultyCommand,
+		&importCommand, &importReceiptCommand, &importTotalDifficultyCommand, &importStateCommand,
 		&snapshotCommand, &supportCommand}
 	return app
 }

--- a/turbo/app/make_app.go
+++ b/turbo/app/make_app.go
@@ -34,6 +34,7 @@ func MakeApp(action cli.ActionFunc, cliFlags []cli.Flag) *cli.App {
 	app.Commands = []*cli.Command{&initCommand,
 		&importCommand, &importReceiptCommand, &importTotalDifficultyCommand, &importStateCommand,
 		&recoverSendersCommand, &recoverLogIndexCommand,
+		&dropLogIndexCommand,
 		&snapshotCommand, &supportCommand}
 	return app
 }

--- a/turbo/app/recover.go
+++ b/turbo/app/recover.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -14,6 +15,8 @@ import (
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth"
+	"github.com/ledgerwatch/erigon/eth/stagedsync"
+	"github.com/ledgerwatch/erigon/ethdb/prune"
 	turboNode "github.com/ledgerwatch/erigon/turbo/node"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/urfave/cli/v2"
@@ -38,6 +41,20 @@ var recoverSendersCommand = cli.Command{
 	Category: "BLOCKCHAIN COMMANDS",
 	Description: `
 The recover command recovers Senders table.`,
+}
+
+var recoverLogIndexCommand = cli.Command{
+	Action:    MigrateFlags(recoverLogIndex),
+	Name:      "recover-log-index",
+	Usage:     "Recover log index",
+	ArgsUsage: "<blockNumFirst> <blockNumLast>",
+	Flags: []cli.Flag{
+		&utils.DataDirFlag,
+		&utils.ChainFlag,
+	},
+	Category: "BLOCKCHAIN COMMANDS",
+	Description: `
+The recover command recovers LogTopicIndex table and LogAddressIndex table.`,
 }
 
 func recoverSenders(ctx *cli.Context) error {
@@ -172,6 +189,133 @@ func RecoverSendersBatch(ethereum *eth.Ethereum, signer *types.Signer, start, en
 			return err
 		}
 	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func recoverLogIndex(ctx *cli.Context) error {
+	if ctx.NArg() < 2 {
+		utils.Fatalf("This command requires an argument.")
+	}
+
+	first, ferr := strconv.ParseInt(ctx.Args().Get(0), 10, 64)
+	last, lerr := strconv.ParseInt(ctx.Args().Get(1), 10, 64)
+	if ferr != nil || lerr != nil {
+		utils.Fatalf("Recover error in parsing parameters: block number not an integer\n")
+	}
+	if first < 0 || last < 0 {
+		utils.Fatalf("Recover error: block number must be greater than 0\n")
+	}
+
+	nodeCfg := turboNode.NewNodConfigUrfave(ctx)
+	ethCfg := turboNode.NewEthConfigUrfave(ctx, nodeCfg)
+
+	stack := makeConfigNode(nodeCfg)
+	defer stack.Close()
+
+	ethereum, err := eth.New(stack, ethCfg)
+	if err != nil {
+		return err
+	}
+	err = ethereum.Init(stack, ethCfg)
+	if err != nil {
+		return err
+	}
+
+	if err := RecoverLogIndex(ethereum, uint64(first), uint64(last)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func RecoverLogIndex(ethereum *eth.Ethereum, first, last uint64) error {
+	// Watch for Ctrl-C while the import is running.
+	// If a signal is received, the import will stop at the next batch.
+	interrupt := make(chan os.Signal, 1)
+	stop := make(chan struct{})
+	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(interrupt)
+	defer close(interrupt)
+	go func() {
+		if _, ok := <-interrupt; ok {
+			log.Info("Interrupted during recovery, stopping at next batch")
+		}
+		close(stop)
+	}()
+	checkInterrupt := func() bool {
+		select {
+		case <-stop:
+			return true
+		default:
+			return false
+		}
+	}
+
+	log.Info("Recovering Log Index")
+	n := first
+	startTime, reportedTime := time.Now(), time.Now()
+	for batch := 0; ; batch++ {
+		if checkInterrupt() {
+			return fmt.Errorf("interrupted")
+		}
+		start := n
+		end := n + recoverBatchSize - 1
+		if end > last {
+			end = last
+		}
+		if err := RecoverLogIndexBatch(ethereum, start, end); err != nil {
+			return err
+		}
+		if end == last {
+			break
+		}
+		n += recoverBatchSize
+
+		if time.Since(reportedTime) >= 8*time.Second {
+			log.Info("Recovering Log Index", "recovered", start, "elapsed", time.Duration(time.Since(startTime)))
+			reportedTime = time.Now()
+		}
+	}
+	return nil
+}
+
+func RecoverLogIndexBatch(ethereum *eth.Ethereum, start, end uint64) error {
+	db := ethereum.ChainDB()
+	tx, err := db.BeginRw(ethereum.SentryCtx())
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// receipt sanity check before log recovery
+	for nr := start; nr <= end; nr++ {
+		block, err := rawdb.ReadBlockByNumber(tx, nr)
+		if err != nil {
+			return err
+		}
+		receipts := rawdb.ReadRawReceipts(tx, nr)
+		receipts.ProcessFieldsForValidation(block)
+		receiptHash := types.DeriveSha(receipts)
+		if receiptHash != block.ReceiptHash() {
+			log.Error("receipt root mismatch", "blockNum", nr, "receiptHash", receiptHash.Hex(), "newReceiptHash", block.ReceiptHash().Hex())
+			return fmt.Errorf("receipt trie root mismatch. blockNum = %d", nr)
+		}
+	}
+
+	pm := prune.DefaultMode
+	dirs := ethereum.Dirs()
+	logPrefix := ""
+	ctx := context.Background()
+
+	cfg := stagedsync.StageLogIndexCfg(db, pm, dirs.Tmp)
+	if err = stagedsync.PromoteLogIndex(logPrefix, tx, start, end, cfg, ctx); err != nil {
+		return err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return err
 	}

--- a/turbo/app/recover.go
+++ b/turbo/app/recover.go
@@ -386,7 +386,7 @@ func RecoverRegenesis(ethereum *eth.Ethereum) error {
 	case networkname.OptimismGoerliChainName:
 		genesisHeader.Root = params.OptimismGoerliStateRoot
 		targetGenesisHash = params.OptimismGoerliGenesisHash
-	case networkname.MainnetChainName:
+	case networkname.OptimismMainnetChainName:
 		genesisHeader.Root = params.OptimismMainnetStateRoot
 		targetGenesisHash = params.OptimismMainnetGenesisHash
 	default:

--- a/turbo/app/recover.go
+++ b/turbo/app/recover.go
@@ -1,0 +1,180 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon/cmd/utils"
+	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/eth"
+	turboNode "github.com/ledgerwatch/erigon/turbo/node"
+	"github.com/ledgerwatch/log/v3"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	recoverBatchSize = 2500
+)
+
+// chainID derived when v = 0
+var overflowedChainID = uint256.NewInt(0x7fffffffffffffee)
+
+var recoverSendersCommand = cli.Command{
+	Action:    MigrateFlags(recoverSenders),
+	Name:      "recover-senders",
+	Usage:     "Recover senders",
+	ArgsUsage: "<blockNumFirst> <blockNumLast>",
+	Flags: []cli.Flag{
+		&utils.DataDirFlag,
+		&utils.ChainFlag,
+	},
+	Category: "BLOCKCHAIN COMMANDS",
+	Description: `
+The recover command recovers Senders table.`,
+}
+
+func recoverSenders(ctx *cli.Context) error {
+	if ctx.NArg() < 2 {
+		utils.Fatalf("This command requires an argument.")
+	}
+
+	first, ferr := strconv.ParseInt(ctx.Args().Get(0), 10, 64)
+	last, lerr := strconv.ParseInt(ctx.Args().Get(1), 10, 64)
+	if ferr != nil || lerr != nil {
+		utils.Fatalf("Recover error in parsing parameters: block number not an integer\n")
+	}
+	if first < 0 || last < 0 {
+		utils.Fatalf("Recover error: block number must be greater than 0\n")
+	}
+
+	nodeCfg := turboNode.NewNodConfigUrfave(ctx)
+	ethCfg := turboNode.NewEthConfigUrfave(ctx, nodeCfg)
+
+	stack := makeConfigNode(nodeCfg)
+	defer stack.Close()
+
+	ethereum, err := eth.New(stack, ethCfg)
+	if err != nil {
+		return err
+	}
+	err = ethereum.Init(stack, ethCfg)
+	if err != nil {
+		return err
+	}
+
+	if err := RecoverSenders(ethereum, uint64(first), uint64(last)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func RecoverSenders(ethereum *eth.Ethereum, first, last uint64) error {
+	// Watch for Ctrl-C while the import is running.
+	// If a signal is received, the import will stop at the next batch.
+	interrupt := make(chan os.Signal, 1)
+	stop := make(chan struct{})
+	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(interrupt)
+	defer close(interrupt)
+	go func() {
+		if _, ok := <-interrupt; ok {
+			log.Info("Interrupted during recovery, stopping at next batch")
+		}
+		close(stop)
+	}()
+	checkInterrupt := func() bool {
+		select {
+		case <-stop:
+			return true
+		default:
+			return false
+		}
+	}
+
+	signer := types.LatestSignerForChainID(ethereum.ChainConfig().ChainID)
+	log.Info("Recovering Senders")
+	n := first
+	startTime, reportedTime := time.Now(), time.Now()
+	for batch := 0; ; batch++ {
+		if checkInterrupt() {
+			return fmt.Errorf("interrupted")
+		}
+		start := n
+		end := n + recoverBatchSize - 1
+		if end > last {
+			end = last
+		}
+		if err := RecoverSendersBatch(ethereum, signer, start, end); err != nil {
+			return err
+		}
+		if end == last {
+			break
+		}
+		n += recoverBatchSize
+
+		if time.Since(reportedTime) >= 8*time.Second {
+			log.Info("Recovering senders", "recovered", start, "elapsed", time.Duration(time.Since(startTime)))
+			reportedTime = time.Now()
+		}
+	}
+	return nil
+}
+
+func RecoverSendersBatch(ethereum *eth.Ethereum, signer *types.Signer, start, end uint64) error {
+	db := ethereum.ChainDB()
+	tx, err := db.BeginRw(ethereum.SentryCtx())
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	for nr := start; nr <= end; nr++ {
+		block, err := rawdb.ReadBlockByNumber(tx, nr)
+		if err != nil {
+			return err
+		}
+		txs := block.Transactions()
+		if len(txs) == 0 {
+			log.Info("Recovery: transactions not found", "blockNum", nr)
+			continue
+		}
+
+		var sendersRecovered []common.Address
+		for _, txn := range txs {
+			from, err := txn.Sender(*signer)
+			if err != nil {
+				if txn.GetChainID().Eq(overflowedChainID) {
+					from = common.Address{}
+				} else {
+					return err
+				}
+			}
+			sendersRecovered = append(sendersRecovered, from)
+		}
+		// sanity check senders included in transactions
+		sendersFromTxs := block.Body().SendersFromTxs()
+		for i := 0; i < len(txs); i++ {
+			if sendersFromTxs[i] != sendersRecovered[i] {
+				log.Error("Recovery mismatch", "blockNum", nr)
+				return fmt.Errorf("recovery mismatch")
+			}
+		}
+
+		if err := rawdb.WriteSenders(tx, block.Hash(), nr, sendersRecovered); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/turbo/app/utils.go
+++ b/turbo/app/utils.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"time"
+
+	"github.com/ledgerwatch/log/v3"
+)
+
+func StatusReporter(msg string, idx *int) chan struct{} {
+	startTime := time.Now()
+	ticker := time.NewTicker(8 * time.Second)
+	quit := make(chan struct{})
+
+	go func(index *int) {
+		for {
+			select {
+			case <-ticker.C:
+				log.Info(msg, "index", *index, "elapsed", time.Duration(time.Since(startTime)))
+			case <-quit:
+				log.Info(msg, "index", *index, "elapsed", time.Duration(time.Since(startTime)))
+				ticker.Stop()
+				return
+			}
+		}
+	}(idx)
+
+	return quit
+}

--- a/turbo/app/utils.go
+++ b/turbo/app/utils.go
@@ -20,9 +20,9 @@ func StatusReporter(msg string, idx *int) chan struct{} {
 		for {
 			select {
 			case <-ticker.C:
-				log.Info(msg, "index", *index, "elapsed", time.Duration(time.Since(startTime)))
+				log.Info(msg, "index", *index, "elapsed", time.Since(startTime))
 			case <-quit:
-				log.Info(msg, "index", *index, "elapsed", time.Duration(time.Since(startTime)))
+				log.Info(msg, "index", *index, "elapsed", time.Since(startTime))
 				ticker.Stop()
 				return
 			}

--- a/turbo/app/utils.go
+++ b/turbo/app/utils.go
@@ -3,8 +3,13 @@ package app
 import (
 	"time"
 
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/log/v3"
 )
+
+var emptyCodeHash = crypto.Keccak256Hash(nil)
+var emptyHash = libcommon.Hash{}
 
 func StatusReporter(msg string, idx *int) chan struct{} {
 	startTime := time.Now()

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -169,5 +169,6 @@ var DefaultFlags = []cli.Flag{
 	&utils.SentinelPortFlag,
 
 	&utils.ImportExecutionFlag,
+	&utils.ImportStateStreamFlag,
 	&utils.GenesisPathFlag,
 }

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -168,5 +168,6 @@ var DefaultFlags = []cli.Flag{
 	&utils.SentinelAddrFlag,
 	&utils.SentinelPortFlag,
 
+	&utils.ImportExecutionFlag,
 	&utils.GenesisPathFlag,
 }


### PR DESCRIPTION
## Bedrock migration

This PR is for generating op-erigon db from op-geth db. This PR will not be merged. The code is for single use.

Refer to [bedrock-migration.md](https://github.com/testinprod-io/op-erigon/blob/pcw109550/bedrock-db-migration/bedrock-migration.md) for details.

Below are Logs and Metrics for optimism goerli. Tested using `M1 Pro` with `512 GB` SSD. 

Export needs op-geth change: Refer to https://github.com/testinprod-io/op-geth/pull/1

### Export using op-geth

```
+------------------------------------------+
| Wed May 31 15:42:46 KST 2023             |
|                                          |
| Export Blocks                            |
+------------------------------------------+
Export done in 1m53.195332667s

real    1m54.130s
user    0m51.176s
sys     0m56.837s
+------------------------------------------+
| Wed May 31 15:44:40 KST 2023             |
|                                          |
| Export Total Difficulty                  |
+------------------------------------------+
Export done in 1m15.773168625s

real    1m16.583s
user    0m51.199s
sys     0m24.479s
+------------------------------------------+
| Wed May 31 15:45:57 KST 2023             |
|                                          |
| Export Receipts                          |
+------------------------------------------+
Export done in 5m13.722576916s

real    5m14.519s
user    3m2.769s
sys     2m0.962s
+------------------------------------------+
| Wed May 31 15:51:11 KST 2023             |
|                                          |
| Export State                             |
+------------------------------------------+

real    3m41.340s
user    2m31.461s
sys     0m30.173s
```

### Import using op-erigon; metrics enabled
```
+------------------------------------------+
| Wed May 31 15:08:55 KST 2023             |
|                                          |
| Import Genesis                           |
+------------------------------------------+

real 0m0.354s
user 0m0.139s
sys  0m0.127s
+------------------------------------------+
| Wed May 31 15:08:55 KST 2023             |
|                                          |
| Recover Genesis                          |
+------------------------------------------+

real 0m2.317s
user 0m0.146s
sys  0m0.039s
+------------------------------------------+
| Wed May 31 15:08:58 KST 2023             |
|                                          |
| Import Blocks                            |
+------------------------------------------+

real 5m53.649s
user 2m21.659s
sys  2m0.902s
+------------------------------------------+
| Wed May 31 15:14:51 KST 2023             |
|                                          |
| Import Total Difficulty                  |
+------------------------------------------+

real 1m12.109s
user 0m27.669s
sys  0m4.788s
+------------------------------------------+
| Wed May 31 15:16:03 KST 2023             |
|                                          |
| Import Receipts                          |
+------------------------------------------+

real 2m5.995s
user 1m27.966s
sys  0m8.244s
+------------------------------------------+
| Wed May 31 15:18:09 KST 2023             |
|                                          |
| Import State                             |
+------------------------------------------+

real 3m31.558s
user 3m15.579s
sys  0m27.161s
+------------------------------------------+
| Wed May 31 15:21:41 KST 2023             |
|                                          |
| Drop Log Index                           |
+------------------------------------------+

real 0m2.542s
user 0m0.430s
sys  0m0.053s
+------------------------------------------+
| Wed May 31 15:21:43 KST 2023             |
|                                          |
| Recover Log Index                        |
+------------------------------------------+

real 3m50.098s
user 2m16.237s
sys  0m20.692s
+------------------------------------------+
| Wed May 31 15:25:34 KST 2023             |
|                                          |
| Recover Senders                          |
+------------------------------------------+

real 7m27.001s
user 6m23.125s
sys  0m11.515s
```

### Resource Monitoring(`memstat`) while Import:

Image captured from Grafana. About `14 GB` is acquired. 
The memory spike is from `Import State` step, which world state trie is imported in jsonl form.

![image](https://github.com/testinprod-io/op-erigon/assets/29061389/85192092-f401-4ad4-b3e5-e4b3e6575ae6)

### Result database stats

Result of `mdbx_stat` is modifed for showing only filled info.
```
➜  erigon git:(pcw109550/bedrock-db-migration) ✗ du -sh erigon_db
 13G erigon_db
➜  erigon git:(pcw109550/bedrock-db-migration) ✗ ./build/bin/mdbx_stat -ef erigon_db/chaindata 
mdbx_stat v0.12.0-71-g1cac6536 (2022-07-28T09:57:31+07:00, T-9a6d7e5b917e5fbd14dc51835fa749d092aa1d72)
Running for erigon_db/chaindata...
Environment Info
  Pagesize: 16384
  Dynamic datafile: 49152..7696581394432 bytes (+2147483648/-4294967296), 3..469762048 pages (+131072/-262144)
  Current mapsize: 7696581394432 bytes, 469762048 pages 
  Current datafile: 15032385536 bytes, 917504 pages
  Last transaction ID: 9211
  Latter reader transaction ID: 9211 (0)
  Max readers: 498
  Number of reader slots uses: 1
Garbage Collection
  Pagesize: 16384
  Tree depth: 1
  Branch pages: 0
  Leaf pages: 1
  Overflow pages: 0
  Entries: 1
Page Usage
  Total: 469762048 100%
  Backed: 917504 0.2%
  Allocated: 836949 0.2%
  Remained: 468925099 99.8%
  Used: 836944 0.2%
  GC: 5 0.0%
  Retained: 5 0.0%
  Reclaimable: 0 0.0%
  Available: 468925099 99.8%
Status of Main DB
  Pagesize: 16384
  Tree depth: 1
  Branch pages: 0
  Leaf pages: 1
  Overflow pages: 0
  Entries: 100
➜  erigon git:(pcw109550/bedrock-db-migration) ✗ ./build/bin/mdbx_stat -a erigon_db/chaindata
mdbx_stat v0.12.0-71-g1cac6536 (2022-07-28T09:57:31+07:00, T-9a6d7e5b917e5fbd14dc51835fa749d092aa1d72)
Running for erigon_db/chaindata...
Status of Main DB
  Pagesize: 16384
  Tree depth: 1
  Branch pages: 0
  Leaf pages: 1
  Overflow pages: 0
  Entries: 100
Status of AccountChangeSet
  Pagesize: 16384
  Tree depth: 1
  Branch pages: 1
  Leaf pages: 236
  Overflow pages: 0
  Entries: 127608
Status of AccountHistory
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 3
  Leaf pages: 784
  Overflow pages: 0
  Entries: 127608
Status of BlockBody
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 46
  Leaf pages: 14399
  Overflow pages: 0
  Entries: 4061226
Status of BlockTransaction
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 150
  Leaf pages: 135163
  Overflow pages: 41979
  Entries: 4061223
Status of BlockTransactionLookup
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 66
  Leaf pages: 16379
  Overflow pages: 0
  Entries: 4061223
Status of CanonicalHeader
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 15
  Leaf pages: 12420
  Overflow pages: 0
  Entries: 4061225
Status of Code
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 17
  Leaf pages: 3335
  Overflow pages: 11256
  Entries: 17312
Status of HashedAccount
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 3
  Leaf pages: 715
  Overflow pages: 0
  Entries: 127608
Status of HashedCodeHash
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 5
  Leaf pages: 976
  Overflow pages: 0
  Entries: 127608
Status of HashedStorage
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 977
  Leaf pages: 42784
  Overflow pages: 0
  Entries: 7992368
Status of Header
  Pagesize: 16384
  Tree depth: 4
  Branch pages: 521
  Leaf pages: 169218
  Overflow pages: 0
  Entries: 4061226
Status of HeaderNumber
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 65
  Leaf pages: 17305
  Overflow pages: 0
  Entries: 4061226
Status of HeadersTotalDifficulty
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 42
  Leaf pages: 13404
  Overflow pages: 0
  Entries: 4061226
Status of LogAddressIndex
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 5
  Leaf pages: 1189
  Overflow pages: 0
  Entries: 30993
Status of LogTopicIndex
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 79
  Leaf pages: 17000
  Overflow pages: 0
  Entries: 1879622
Status of PlainCodeHash
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 3
  Leaf pages: 843
  Overflow pages: 0
  Entries: 127608
Status of PlainState
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 971
  Leaf pages: 43076
  Overflow pages: 0
  Entries: 8119976
Status of Receipt
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 15
  Leaf pages: 11857
  Overflow pages: 0
  Entries: 4061225
Status of StorageChangeSet
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 590
  Leaf pages: 21319
  Overflow pages: 0
  Entries: 7992368
Status of StorageHistory
  Pagesize: 16384
  Tree depth: 4
  Branch pages: 523
  Leaf pages: 70916
  Overflow pages: 0
  Entries: 7992368
Status of TransactionLog
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 181
  Leaf pages: 133542
  Overflow pages: 35071
  Entries: 3589496
Status of TxSender
  Pagesize: 16384
  Tree depth: 3
  Branch pages: 55
  Leaf pages: 17431
  Overflow pages: 0
  Entries: 4061223
```