### PR TITLE
Handle Deposit Transaction RLP encoding

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -973,6 +973,8 @@ func (bb Body) payloadSize() (payloadSize int, txsLen, unclesLen, withdrawalsLen
 			txLen = t.EncodingSize()
 		case *DynamicFeeTransaction:
 			txLen = t.EncodingSize()
+		case *DepositTx:
+			txLen = t.EncodingSize()
 		}
 		if txLen >= 56 {
 			txsLen += bitsToBytes(bits.Len(uint(txLen)))
@@ -1041,6 +1043,10 @@ func (bb Body) EncodeRLP(w io.Writer) error {
 				return err
 			}
 		case *DynamicFeeTransaction:
+			if err := t.EncodeRLP(w); err != nil {
+				return err
+			}
+		case *DepositTx:
 			if err := t.EncodeRLP(w); err != nil {
 				return err
 			}

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -208,6 +208,8 @@ func (tp TransactionsPacket) EncodeRLP(w io.Writer) error {
 			txLen = t.EncodingSize()
 		case *types.DynamicFeeTransaction:
 			txLen = t.EncodingSize()
+		case *types.DepositTx:
+			txLen = t.EncodingSize()
 		}
 		if txLen >= 56 {
 			txsLen += (bits.Len(uint(txLen)) + 7) / 8
@@ -234,6 +236,10 @@ func (tp TransactionsPacket) EncodeRLP(w io.Writer) error {
 				return err
 			}
 		case *types.DynamicFeeTransaction:
+			if err := t.EncodeRLP(w); err != nil {
+				return err
+			}
+		case *types.DepositTx:
 			if err := t.EncodeRLP(w); err != nil {
 				return err
 			}
@@ -523,6 +529,8 @@ func (ptp PooledTransactionsPacket) EncodeRLP(w io.Writer) error {
 			txLen = t.EncodingSize()
 		case *types.DynamicFeeTransaction:
 			txLen = t.EncodingSize()
+		case *types.DepositTx:
+			txLen = t.EncodingSize()
 		}
 		if txLen >= 56 {
 			txsLen += (bits.Len(uint(txLen)) + 7) / 8
@@ -549,6 +557,10 @@ func (ptp PooledTransactionsPacket) EncodeRLP(w io.Writer) error {
 				return err
 			}
 		case *types.DynamicFeeTransaction:
+			if err := t.EncodeRLP(w); err != nil {
+				return err
+			}
+		case *types.DepositTx:
 			if err := t.EncodeRLP(w); err != nil {
 				return err
 			}
@@ -597,6 +609,8 @@ func (ptp66 PooledTransactionsPacket66) EncodeRLP(w io.Writer) error {
 			txLen = t.EncodingSize()
 		case *types.DynamicFeeTransaction:
 			txLen = t.EncodingSize()
+		case *types.DepositTx:
+			txLen = t.EncodingSize()
 		}
 		if txLen >= 56 {
 			txsLen += (bits.Len(uint(txLen)) + 7) / 8
@@ -640,6 +654,10 @@ func (ptp66 PooledTransactionsPacket66) EncodeRLP(w io.Writer) error {
 				return err
 			}
 		case *types.DynamicFeeTransaction:
+			if err := t.EncodeRLP(w); err != nil {
+				return err
+			}
+		case *types.DepositTx:
 			if err := t.EncodeRLP(w); err != nil {
 				return err
 			}


### PR DESCRIPTION
There was no proper RLP encoding for encoding body. Also deposit transactions related using eth protocol was also not properly RLP encoded.

This resulted in database sync failure; p2p sync between two op-erigon clients. To be more specific, after `GET_BLOCK_BODIES_66` is sent, the receiver creates outbound messages having type `BLOCK_BODIES_66` which contains body of specific block. The body was empty because the block had only deposit transactions, and deposit transaction was not marshaled, resulting in decoding failure on sender side.

Added proper RLP encoding logic for deposit transactions.

Added `block_test.go::TestCanEncodeAndDecodeBodyTransactions` test for checking RLP encoding logic for each transaction type including deposit transactions. 

