### PR TITLE
Fix tracing API for Prebedrock relay

### DIFF
--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -72,6 +72,30 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 		return fmt.Errorf("invalid arguments; block with hash %x not found", hash)
 	}
 
+	chainConfig, err := api.chainConfig(tx)
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+
+	if chainConfig.IsOptimismPreBedrock(block.NumberU64()) {
+		if api.historicalRPCService == nil {
+			return rpc.ErrNoHistoricalFallback
+		}
+		var traceResult interface{}
+		// relay using block hash
+		if err := api.relayToHistoricalBackend(ctx, &traceResult, "debug_traceBlockByHash", block.Hash(), config); err != nil {
+			return fmt.Errorf("historical backend error: %w", err)
+		}
+		// stream out relayed response
+		result, err := json.Marshal(&traceResult)
+		if err != nil {
+			return err
+		}
+		stream.WriteRaw(string(result))
+		return nil
+	}
+
 	// if we've pruned this history away for this block then just return early
 	// to save any red herring errors
 	err = api.BaseAPI.checkPruneHistory(tx, block.NumberU64())
@@ -96,11 +120,6 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 	}
 	if parentBlock != nil {
 		excessDataGas = parentBlock.ExcessDataGas()
-	}
-	chainConfig, err := api.chainConfig(tx)
-	if err != nil {
-		stream.WriteNil()
-		return err
 	}
 	engine := api.engine()
 

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -315,6 +316,10 @@ func (api *PrivateDebugAPIImpl) TraceCall(ctx context.Context, args ethapi.CallA
 	blockNumber, hash, _, err := rpchelper.GetBlockNumber(blockNrOrHash, dbtx, api.filters)
 	if err != nil {
 		return fmt.Errorf("get block number: %v", err)
+	}
+
+	if chainConfig.IsOptimismPreBedrock(blockNumber) {
+		return errors.New("l2geth does not have a debug_traceCall method")
 	}
 
 	err = api.BaseAPI.checkPruneHistory(dbtx, blockNumber)


### PR DESCRIPTION
Enable prebedrock relay for 
* `debug_traceBlockByNumber`
* `debug_traceBlockByHash`

Early return because `l2geth` does not support RPC methods:
* `debug_traceCall`

I may also disable `debug_traceCallMany` which is erigon specific method, but this is currently out of scope. Will do in separate PR.