### PR TITLE
Ignore hive daisy chain test in CI

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -38,10 +38,11 @@ jobs:
       - name: build erigon image (root permissions)
         run: sudo DOCKER_TAG=testinprod/op-erigon:latest DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
 
+      # exclude optimism/daisy-chain because it exhausts github ci disk space for downloading op-goerli database
       - name: run hive and parse output
         run: |
           sudo mkdir -p /results-${{ github.run_id }}
-          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work testinprod/hive:latest --sim optimism --results-root=/work/results-${{ github.run_id }} --client go-ethereum,op-erigon,op-proposer,op-batcher,op-node
+          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work testinprod/hive:latest --sim "^optimism/(rpc|l1ops|p2p)$" --results-root=/work/results-${{ github.run_id }} --client go-ethereum,op-erigon,op-proposer,op-batcher,op-node
           docker run --rm --pull always -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work --entrypoint /app/hivecioutput testinprod/hive:latest --resultsdir=/work/results-${{ github.run_id }} --outdir=/work/results-${{ github.run_id }} --exclusionsfile=/work/hive/exclusions.json
 
       - name: clean up containers


### PR DESCRIPTION
Temporarily disable `optimism/daisy-chain` test suite because it exhausts github ci disk space for downloading op-goerli database and unexpected database download timeout.

From https://github.com/testinprod-io/op-erigon/actions/runs/5582548521, 
> You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 0 MB
 
According to the [Github CI docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), we should change the hardware spec. This will be done in separate PR, and reenable disabled hive test suite.
