### PR TITLE
Add L1CostFunc for supporting `callMany` RPCs

### DIFF
--- a/cmd/rpcdaemon/commands/eth_callMany.go
+++ b/cmd/rpcdaemon/commands/eth_callMany.go
@@ -170,6 +170,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 		GasLimit:    parent.GasLimit,
 		BaseFee:     &baseFee,
 	}
+	blockCtx.L1CostFunc = types.NewL1CostFunc(chainConfig, st)
 
 	// Get a new instance of the EVM
 	evm = vm.NewEVM(blockCtx, txCtx, st, chainConfig, vm.Config{Debug: false})

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -474,6 +474,7 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 		GasLimit:    parent.GasLimit,
 		BaseFee:     &baseFee,
 	}
+	blockCtx.L1CostFunc = types.NewL1CostFunc(chainConfig, st)
 
 	// Get a new instance of the EVM
 	evm = vm.NewEVM(blockCtx, txCtx, st, chainConfig, vm.Config{Debug: false})


### PR DESCRIPTION
This PR enables `eth_callMany` RPC and `trace_callMany` RPC for op-erigon.

Tested manually using below script.
```python
if __name__ == "__main__":
    client = Web3(provider=Web3.HTTPProvider(endpoint_uri=endpoint_uri))
    wallet_address = Web3.toChecksumAddress(
        "0x2d2cc0eb095e43204e0c087e07dbf95909650939"
    )
    token_a = Web3.toChecksumAddress("0x4200000000000000000000000000000000000042")
    balance_of = Web3.toHex(Web3.sha3(text="balanceOf(address)"))
    balance_of = balance_of[0:10]
    encoded_address = encode_single("address", wallet_address)
    data = balance_of + encoded_address.hex()
    tx = {
        # "from": wallet_address,
        "to": token_a,
        "data": data,
        "gas": hex(500000),
    }
    payload = json.dumps(
        {
            "jsonrpc": "2.0",
            "id": 1,
            "method": "eth_callMany",
            "params": [
                [{"transactions": [tx], "blockOverride": {"baseFee": hex(0)}}],
                {
                    "blockNumber": "latest",
                    "transactionIndex": 0,
                },
            ],
        }
    )
    payload = json.dumps(
        {
            "jsonrpc": "2.0",
            "id": 1,
            "method": "trace_callMany",
            "params": [
                [
                    [
                        {
                            "from": wallet_address,
                            "to": token_a,
                        },
                        ["trace"],
                    ],
                    [
                        {
                            "from": wallet_address,
                            "to": token_a,
                        },
                        ["trace"],
                    ],
                ],
                "latest",
            ],
        }
    )
```