### PR TITLE
Tx Type Statistics

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"math/big"
-	"net/http"
 	_ "net/http/pprof" //nolint:gosec
 	"os"
 	"path/filepath"
@@ -1435,11 +1434,11 @@ func main() {
 		}
 		defer pprof.StopCPUProfile()
 	}
-	go func() {
-		if err := http.ListenAndServe("localhost:6960", nil); err != nil {
-			log.Error("Failure in running pprof server", "err", err)
-		}
-	}()
+	// go func() {
+	// 	if err := http.ListenAndServe("localhost:6960", nil); err != nil {
+	// 		log.Error("Failure in running pprof server", "err", err)
+	// 	}
+	// }()
 
 	var err error
 	switch *action {

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -886,6 +886,7 @@ func txTypeStat(chaindata string, startBlock uint64, endBlock uint64, chunkSize 
 	defer tx.Rollback()
 
 	stats := make(map[int]int)
+
 	for i := startBlock; i < endBlock; i += chunkSize {
 		start := i
 		end := i + chunkSize
@@ -896,14 +897,22 @@ func txTypeStat(chaindata string, startBlock uint64, endBlock uint64, chunkSize 
 		if err != nil {
 			return err
 		}
+		partialStats := make(map[int]int)
+		partialTxCount := 0
 		for _, tx := range txs {
 			txn, err := types.DecodeTransaction(tx)
 			if err != nil {
 				return err
 			}
-			stats[int(txn.Type())]++
+			partialStats[int(txn.Type())]++
+			partialTxCount++
 		}
-		fmt.Println(start, end-1, stats)
+		percentage := 100 * float64(partialStats[0]) / float64(partialTxCount-partialStats[126])
+		fmt.Println("Partial Stat legacy tx percentage excluding DepositTx:", percentage)
+		fmt.Println(start, end-1, partialStats)
+		for k, v := range partialStats {
+			stats[k] += v
+		}
 		totalTxCount := 0
 		totalDepositTxCount := 0
 		totalLegacyTxCount := 0
@@ -914,7 +923,7 @@ func txTypeStat(chaindata string, startBlock uint64, endBlock uint64, chunkSize 
 		totalDepositTxCount += stats[126]
 		fmt.Println("Total tx count excluding DepositTx:", totalTxCount-totalDepositTxCount)
 		fmt.Println("Total LegacyTx count:", totalLegacyTxCount)
-		percentage := 100 * float64(totalLegacyTxCount) / float64(totalTxCount-totalDepositTxCount)
+		percentage = 100 * float64(totalLegacyTxCount) / float64(totalTxCount-totalDepositTxCount)
 		fmt.Println("LegacyTx percentage excluding DepositTx:", percentage)
 		fmt.Println()
 	}

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -879,7 +879,7 @@ func fixState(chaindata string) error {
 func txTypeMetric(chaindata string, startBlock uint64, endBlock uint64) error {
 	db := mdbx.MustOpen(chaindata)
 	defer db.Close()
-	tx, err := db.BeginRw(context.Background())
+	tx, err := db.BeginRo(context.Background())
 	if err != nil {
 		return err
 	}

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -876,7 +876,7 @@ func fixState(chaindata string) error {
 	return tx.Commit()
 }
 
-func txTypeMetric(chaindata string, startBlock uint64, endBlock uint64, chunkSize uint64) error {
+func txTypeStat(chaindata string, startBlock uint64, endBlock uint64, chunkSize uint64) error {
 	db := mdbx.MustOpen(chaindata)
 	defer db.Close()
 	tx, err := db.BeginRo(context.Background())
@@ -1522,8 +1522,8 @@ func main() {
 	case "trimTxs":
 		err = trimTxs(*chaindata)
 
-	case "txTypeMetric":
-		err = txTypeMetric(*chaindata, uint64(*startBlock), uint64(*endBlock), uint64(*chunkSize))
+	case "txTypeStat":
+		err = txTypeStat(*chaindata, uint64(*startBlock), uint64(*endBlock), uint64(*chunkSize))
 
 	case "scanTxs":
 		err = scanTxs(*chaindata)

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -893,7 +893,7 @@ func txTypeMetric(chaindata string, startBlock uint64, endBlock uint64) error {
 		if end >= endBlock {
 			end = endBlock
 		}
-		txs, err := rawdb.RawTransactionsRange(tx, start, end)
+		txs, err := rawdb.RawTransactionsRange(tx, start, end - 1)
 		if err != nil {
 			return err
 		}

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -893,7 +893,7 @@ func txTypeMetric(chaindata string, startBlock uint64, endBlock uint64) error {
 		if end >= endBlock {
 			end = endBlock
 		}
-		txs, err := rawdb.RawTransactionsRange(tx, start, end - 1)
+		txs, err := rawdb.RawTransactionsRange(tx, start, end-1)
 		if err != nil {
 			return err
 		}
@@ -904,7 +904,7 @@ func txTypeMetric(chaindata string, startBlock uint64, endBlock uint64) error {
 			}
 			stats[int(txn.Type())]++
 		}
-		fmt.Println(stats)
+		fmt.Println(start, end-1, stats)
 	}
 	fmt.Println(stats)
 	return nil

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -904,6 +904,19 @@ func txTypeStat(chaindata string, startBlock uint64, endBlock uint64, chunkSize 
 			stats[int(txn.Type())]++
 		}
 		fmt.Println(start, end-1, stats)
+		totalTxCount := 0
+		totalDepositTxCount := 0
+		totalLegacyTxCount := 0
+		for _, v := range stats {
+			totalTxCount += v
+		}
+		totalLegacyTxCount += stats[0]
+		totalDepositTxCount += stats[126]
+		fmt.Println("Total tx count excluding DepositTx:", totalTxCount-totalDepositTxCount)
+		fmt.Println("Total LegacyTx count:", totalLegacyTxCount)
+		percentage := 100 * float64(totalLegacyTxCount) / float64(totalTxCount-totalDepositTxCount)
+		fmt.Println("LegacyTx percentage excluding DepositTx:", percentage)
+		fmt.Println()
 	}
 	fmt.Println(stats)
 	return nil

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -69,6 +69,7 @@ var (
 	hash       = flag.String("hash", "0x00", "image for preimage or state root for testBlockHashes action")
 	startBlock = flag.Int("startBlock", 1, "specifies start block number")
 	endBlock   = flag.Int("endBlock", 1, "specifies end block number")
+	chunkSize  = flag.Int("chunkSize", 1, "specifies chunk size")
 )
 
 func dbSlice(chaindata string, bucket string, prefix []byte) {
@@ -875,7 +876,7 @@ func fixState(chaindata string) error {
 	return tx.Commit()
 }
 
-func txTypeMetric(chaindata string, startBlock uint64, endBlock uint64) error {
+func txTypeMetric(chaindata string, startBlock uint64, endBlock uint64, chunkSize uint64) error {
 	db := mdbx.MustOpen(chaindata)
 	defer db.Close()
 	tx, err := db.BeginRo(context.Background())
@@ -885,7 +886,6 @@ func txTypeMetric(chaindata string, startBlock uint64, endBlock uint64) error {
 	defer tx.Rollback()
 
 	stats := make(map[int]int)
-	chunkSize := uint64(1000)
 	for i := startBlock; i < endBlock; i += chunkSize {
 		start := i
 		end := i + chunkSize
@@ -1523,7 +1523,7 @@ func main() {
 		err = trimTxs(*chaindata)
 
 	case "txTypeMetric":
-		err = txTypeMetric(*chaindata, uint64(*startBlock), uint64(*endBlock))
+		err = txTypeMetric(*chaindata, uint64(*startBlock), uint64(*endBlock), uint64(*chunkSize))
 
 	case "scanTxs":
 		err = scanTxs(*chaindata)


### PR DESCRIPTION
Data analysis for stats of transaction type.

Example usage:
```
./build/bin/hack --chaindata=/data/database-op-erigon-mainnet-sync/chaindata --action txTypeStat --startBlock=105235063 --endBlock=108421982 --chunkSize=10000 | tee tx_type_stat_mainnet.log
```

Wont be merged.

Example output

mainnet: 105235063(bedrock genesis) to 108421982: 
```
Total tx count excluding DepositTx: 41862102
Total LegacyTx count: 19665928
LegacyTx percentage excluding DepositTx: 46.977879897191976

map[0:19665928 1:1709 2:22194465 126:6463083]
```

goerli: 4061224(bedrock genesis) to 13507550: 
```
Total tx count excluding DepositTx: 18313637
Total LegacyTx count: 3647449
LegacyTx percentage excluding DepositTx: 19.916573644000916

map[0:3647449 1:212 2:14665976 126:23955794]
```