### PR TITLE
Increase timeout of integration test workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,10 +154,10 @@ test3:
 
 ## test-integration:                  run integration tests with a 30m timeout
 test-integration:
-	$(GOTEST) --timeout 30m -tags $(BUILD_TAGS),integration
+	$(GOTEST) --timeout 60m -tags $(BUILD_TAGS),integration
 
 test3-integration:
-	$(GOTEST) --timeout 30m -tags $(BUILD_TAGS),integration,e3
+	$(GOTEST) --timeout 60m -tags $(BUILD_TAGS),integration,e3
 
 ## lint:                              run golangci-lint with .golangci.yml config file
 lint:


### PR DESCRIPTION
Integration tests workflow often [fails](https://github.com/testinprod-io/op-erigon/actions/runs/6302155758/job/17108748952) with the following error:
```
panic: test timed out after 30m0s
```
[succeeded case](https://github.com/testinprod-io/op-erigon/actions/runs/6295630565/job/17089201332) took about ~30min. So I think this is just a real timeout, not a problem such as stuck process or something..

FYI, hive workflow also fails but cannot reproduce in my machine. need more investigation.