### PR TITLE
[Canyon Hard Fork] Add Canyon network upgrade flags

### DIFF
--- a/cmd/erigon-el/backend/backend.go
+++ b/cmd/erigon-el/backend/backend.go
@@ -251,7 +251,7 @@ func NewBackend(stack *node.Node, config *ethconfig.Config, logger log.Logger) (
 			genesisSpec = nil
 		}
 		var genesisErr error
-		chainConfig, genesis, genesisErr = core.WriteGenesisBlock(tx, genesisSpec, config.OverrideShanghaiTime, tmpdir, logger)
+		chainConfig, genesis, genesisErr = core.WriteGenesisBlock(tx, genesisSpec, config.OverrideShanghaiTime, config.OverrideOptimismCanyonTime, tmpdir, logger)
 		if _, ok := genesisErr.(*chain.ConfigCompatError); genesisErr != nil && !ok {
 			return genesisErr
 		}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -21,13 +21,14 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
-	"github.com/urfave/cli/v2"
 	"math/big"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/urfave/cli/v2"
 
 	"golang.org/x/exp/slices"
 
@@ -111,6 +112,10 @@ var (
 	OverrideShanghaiTime = flags.BigFlag{
 		Name:  "override.shanghaiTime",
 		Usage: "Manually specify Shanghai fork time, overriding the bundled setting",
+	}
+	OverrideOptimismCanyonFlag = flags.BigFlag{
+		Name:  "override.canyon",
+		Usage: "Manually specify the Optimism Canyon fork time, overriding the bundled setting",
 	}
 	// Ethash settings
 	EthashCachesInMemoryFlag = cli.IntFlag{
@@ -1638,7 +1643,10 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		cfg.Genesis = readGenesis(ctx.String(GenesisPathFlag.Name))
 		//log.Info("Using custom developer period", "seconds", cfg.Genesis.Config.Clique.Period)
 	}
-
+	if ctx.IsSet(OverrideOptimismCanyonFlag.Name) {
+		cfg.OverrideOptimismCanyonTime = flags.GlobalBig(ctx, OverrideOptimismCanyonFlag.Name)
+		cfg.TxPool.OverrideOptimismCanyonTime = cfg.OverrideOptimismCanyonTime
+	}
 	if ctx.IsSet(OverrideShanghaiTime.Name) {
 		cfg.OverrideShanghaiTime = flags.GlobalBig(ctx, OverrideShanghaiTime.Name)
 		cfg.TxPool.OverrideShanghaiTime = cfg.OverrideShanghaiTime

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -33,7 +33,7 @@ func TestGenesisBlockHashes(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer tx.Rollback()
-		_, block, err := core.WriteGenesisBlock(tx, genesis, nil, "", logger)
+		_, block, err := core.WriteGenesisBlock(tx, genesis, nil, nil, "", logger)
 		require.NoError(t, err)
 		expect := params.GenesisHashByChainName(network)
 		require.NotNil(t, expect, network)
@@ -80,13 +80,13 @@ func TestCommitGenesisIdempotency(t *testing.T) {
 	defer tx.Rollback()
 
 	genesis := core.GenesisBlockByChainName(networkname.MainnetChainName)
-	_, _, err = core.WriteGenesisBlock(tx, genesis, nil, "", logger)
+	_, _, err = core.WriteGenesisBlock(tx, genesis, nil, nil, "", logger)
 	require.NoError(t, err)
 	seq, err := tx.ReadSequence(kv.EthTx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), seq)
 
-	_, _, err = core.WriteGenesisBlock(tx, genesis, nil, "", logger)
+	_, _, err = core.WriteGenesisBlock(tx, genesis, nil, nil, "", logger)
 	require.NoError(t, err)
 	seq, err = tx.ReadSequence(kv.EthTx)
 	require.NoError(t, err)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -281,7 +281,7 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 			genesisSpec = nil
 		}
 		var genesisErr error
-		chainConfig, genesis, genesisErr = core.WriteGenesisBlock(tx, genesisSpec, config.OverrideShanghaiTime, tmpdir, logger)
+		chainConfig, genesis, genesisErr = core.WriteGenesisBlock(tx, genesisSpec, config.OverrideShanghaiTime, config.OverrideOptimismCanyonTime, tmpdir, logger)
 		if _, ok := genesisErr.(*chain.ConfigCompatError); genesisErr != nil && !ok {
 			return genesisErr
 		}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -245,7 +245,8 @@ type Config struct {
 	SentinelAddr                string
 	SentinelPort                uint64
 
-	OverrideShanghaiTime *big.Int `toml:",omitempty"`
+	OverrideShanghaiTime       *big.Int `toml:",omitempty"`
+	OverrideOptimismCanyonTime *big.Int `toml:",omitempty"`
 
 	DropUselessPeers bool
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ledgerwatch/erigon
 go 1.19
 
 //fork with minor protobuf file changes and txpool support
-replace github.com/ledgerwatch/erigon-lib v0.0.0-20230627104814-797724496a65 => github.com/testinprod-io/erigon-lib v0.0.0-20230724082815-b7b8746e624b
+replace github.com/ledgerwatch/erigon-lib v0.0.0-20230627104814-797724496a65 => github.com/testinprod-io/erigon-lib v0.0.0-20231102042317-293c0e76a349
 
 //for local dev:
 //replace github.com/ledgerwatch/erigon-lib v0.0.0-20230423044930-fc9dd74e6407 => ../erigon-lib

--- a/go.sum
+++ b/go.sum
@@ -745,8 +745,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/supranational/blst v0.3.10 h1:CMciDZ/h4pXDDXQASe8ZGTNKUiVNxVVA5hpci2Uuhuk=
 github.com/supranational/blst v0.3.10/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/testinprod-io/erigon-lib v0.0.0-20230724082815-b7b8746e624b h1:cPYa78vooawGwLNQ2YlaP7/7Cwkmoerua2e7zS/DsJg=
-github.com/testinprod-io/erigon-lib v0.0.0-20230724082815-b7b8746e624b/go.mod h1:yq49cI1Z1S+aS0gj6ERZU03UIrseMmDRj4zWa1EA96Y=
+github.com/testinprod-io/erigon-lib v0.0.0-20231102042317-293c0e76a349 h1:ukPVzVJeJ/wt0mJd0HaxT/FCvIysNMPV6gwSTGXBr50=
+github.com/testinprod-io/erigon-lib v0.0.0-20231102042317-293c0e76a349/go.mod h1:yq49cI1Z1S+aS0gj6ERZU03UIrseMmDRj4zWa1EA96Y=
 github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e h1:cR8/SYRgyQCt5cNCMniB/ZScMkhI9nk8U5C7SbISXjo=
 github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e/go.mod h1:Tu4lItkATkonrYuvtVjG0/rhy15qrNGNTjPdaphtZ/8=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -146,6 +146,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.HeimdallgRPCAddressFlag,
 	&utils.EthStatsURLFlag,
 	&utils.OverrideShanghaiTime,
+	&utils.OverrideOptimismCanyonFlag,
 	&utils.RollupSequencerHTTPFlag,
 	&utils.RollupHistoricalRPCFlag,
 	&utils.RollupHistoricalRPCTimeoutFlag,


### PR DESCRIPTION
- Add canyon override flag(`--override.canyon`)
- Pin erigon-lib as https://github.com/testinprod-io/erigon-lib/pull/24/commits/293c0e76a349ab9ece9113a6b4d458620773803a, part of https://github.com/testinprod-io/erigon-lib/pull/24.