### PR TITLE
[Canyon Hard Fork] Change EIP 1559 Denominator with Canyon

### DIFF
--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -537,7 +537,7 @@ func newRPCBorTransaction(opaqueTx types.Transaction, txHash common.Hash, blockH
 func newRPCPendingTransaction(tx types.Transaction, current *types.Header, config *chain.Config) *RPCTransaction {
 	var baseFee *big.Int
 	if current != nil {
-		baseFee = misc.CalcBaseFee(config, current)
+		baseFee = misc.CalcBaseFee(config, current, current.Time+1)
 	}
 	return newRPCTransaction(tx, common.Hash{}, 0, 0, baseFee, nil)
 }

--- a/consensus/misc/eip1559_test.go
+++ b/consensus/misc/eip1559_test.go
@@ -40,6 +40,18 @@ func config() *chain.Config {
 	return config
 }
 
+func opConfig() *chain.Config {
+	config := copyConfig(params.TestChainConfig)
+	config.LondonBlock = big.NewInt(5)
+	config.CanyonTime = big.NewInt(10)
+	config.Optimism = &chain.OptimismConfig{
+		EIP1559Elasticity:            6,
+		EIP1559Denominator:           50,
+		EIP1559DenominatorPostCanyon: 250,
+	}
+	return config
+}
+
 // TestBlockGasLimits tests the gasLimit checks for blocks both across
 // the EIP-1559 boundary and post-1559 blocks
 func TestBlockGasLimits(t *testing.T) {
@@ -109,7 +121,40 @@ func TestCalcBaseFee(t *testing.T) {
 			GasUsed:  test.parentGasUsed,
 			BaseFee:  big.NewInt(test.parentBaseFee),
 		}
-		if have, want := CalcBaseFee(config(), parent), big.NewInt(test.expectedBaseFee); have.Cmp(want) != 0 {
+		if have, want := CalcBaseFee(config(), parent, 0), big.NewInt(test.expectedBaseFee); have.Cmp(want) != 0 {
+			t.Errorf("test %d: have %d  want %d, ", i, have, want)
+		}
+	}
+}
+
+// TestCalcBaseFeeOptimism assumes all blocks are 1559-blocks but tests the Canyon activation
+func TestCalcBaseFeeOptimism(t *testing.T) {
+	tests := []struct {
+		parentBaseFee   int64
+		parentGasLimit  uint64
+		parentGasUsed   uint64
+		expectedBaseFee int64
+		postCanyon      bool
+	}{
+		{params.InitialBaseFee, 30_000_000, 5_000_000, params.InitialBaseFee, false}, // usage == target
+		{params.InitialBaseFee, 30_000_000, 4_000_000, 996000000, false},             // usage below target
+		{params.InitialBaseFee, 30_000_000, 10_000_000, 1020000000, false},           // usage above target
+		{params.InitialBaseFee, 30_000_000, 5_000_000, params.InitialBaseFee, true},  // usage == target
+		{params.InitialBaseFee, 30_000_000, 4_000_000, 999200000, true},              // usage below target
+		{params.InitialBaseFee, 30_000_000, 10_000_000, 1004000000, true},            // usage above target
+	}
+	for i, test := range tests {
+		parent := &types.Header{
+			Number:   common.Big32,
+			GasLimit: test.parentGasLimit,
+			GasUsed:  test.parentGasUsed,
+			BaseFee:  big.NewInt(test.parentBaseFee),
+			Time:     6,
+		}
+		if test.postCanyon {
+			parent.Time = 8
+		}
+		if have, want := CalcBaseFee(opConfig(), parent, parent.Time+2), big.NewInt(test.expectedBaseFee); have.Cmp(want) != 0 {
 			t.Errorf("test %d: have %d  want %d, ", i, have, want)
 		}
 	}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -591,7 +591,7 @@ func MakeEmptyHeader(parent *types.Header, chainConfig *chain.Config, timestamp 
 	parentGasLimit := parent.GasLimit
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
 	if chainConfig.IsLondon(header.Number.Uint64()) {
-		header.BaseFee = misc.CalcBaseFee(chainConfig, parent)
+		header.BaseFee = misc.CalcBaseFee(chainConfig, parent, timestamp)
 		if !chainConfig.IsLondon(parent.Number.Uint64()) {
 			parentGasLimit = parent.GasLimit * chainConfig.ElasticityMultiplier(params.ElasticityMultiplier)
 		}

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -83,7 +83,7 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 		bf.baseFee = new(big.Int)
 	}
 	if chainconfig.IsLondon(bf.blockNumber + 1) {
-		bf.nextBaseFee = misc.CalcBaseFee(chainconfig, bf.header)
+		bf.nextBaseFee = misc.CalcBaseFee(chainconfig, bf.header, bf.header.Time+1)
 	} else {
 		bf.nextBaseFee = new(big.Int)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ledgerwatch/erigon
 go 1.19
 
 //fork with minor protobuf file changes and txpool support
-replace github.com/ledgerwatch/erigon-lib v0.0.0-20230627104814-797724496a65 => github.com/testinprod-io/erigon-lib v0.0.0-20231102042317-293c0e76a349
+replace github.com/ledgerwatch/erigon-lib v0.0.0-20230627104814-797724496a65 => github.com/testinprod-io/erigon-lib v0.0.0-20231102054516-b93d9d11c10f
 
 //for local dev:
 //replace github.com/ledgerwatch/erigon-lib v0.0.0-20230423044930-fc9dd74e6407 => ../erigon-lib

--- a/go.sum
+++ b/go.sum
@@ -745,8 +745,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/supranational/blst v0.3.10 h1:CMciDZ/h4pXDDXQASe8ZGTNKUiVNxVVA5hpci2Uuhuk=
 github.com/supranational/blst v0.3.10/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/testinprod-io/erigon-lib v0.0.0-20231102042317-293c0e76a349 h1:ukPVzVJeJ/wt0mJd0HaxT/FCvIysNMPV6gwSTGXBr50=
-github.com/testinprod-io/erigon-lib v0.0.0-20231102042317-293c0e76a349/go.mod h1:yq49cI1Z1S+aS0gj6ERZU03UIrseMmDRj4zWa1EA96Y=
+github.com/testinprod-io/erigon-lib v0.0.0-20231102054516-b93d9d11c10f h1:6/GcZLIgvF+LsbFiDabkModKXjAZml+5nddMix5XNes=
+github.com/testinprod-io/erigon-lib v0.0.0-20231102054516-b93d9d11c10f/go.mod h1:yq49cI1Z1S+aS0gj6ERZU03UIrseMmDRj4zWa1EA96Y=
 github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e h1:cR8/SYRgyQCt5cNCMniB/ZScMkhI9nk8U5C7SbISXjo=
 github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e/go.mod h1:Tu4lItkATkonrYuvtVjG0/rhy15qrNGNTjPdaphtZ/8=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=

--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -322,7 +322,7 @@ func (h *Hook) AfterRun(tx kv.Tx, finishProgressBefore uint64) error {
 	}
 
 	if notifications != nil && notifications.Accumulator != nil && currentHeder != nil {
-		pendingBaseFee := misc.CalcBaseFee(h.chainConfig, currentHeder)
+		pendingBaseFee := misc.CalcBaseFee(h.chainConfig, currentHeder, 0)
 		if currentHeder.Number.Uint64() == 0 {
 			notifications.Accumulator.StartChange(0, currentHeder.Hash(), nil, false)
 		}


### PR DESCRIPTION
All codes referenced from
- https://github.com/ethereum-optimism/op-geth/pull/165

## Description

For canyon, EIP 1559 denominator is updated from `50` to `250`.  Adding explicit timestamp parameter to `CalcBaseFee` method. In some cases(for pending transactions, fee history)the base fee may not be accurate if the exact timestamp of the block is not known.

Lets review why this change is needed. Referring [EIP 1559](https://eips.ethereum.org/EIPS/eip-1559) and current [Linear EIP 1559 mechanics](https://dankradfeist.de/ethereum/2022/03/16/exponential-eip1559.html), 

Let $T$ be the gas target, and $A$ be max base fee change denominator. Each block $B_{i}$ where $i$ is a block number has a base fee of $b_{i}$ and let $g_{i}$ be the total gas consumed in the block $B_{i}$. Update rule for base fee:

$$b_{i + 1} = b_{i} \left( 1 + \frac{1}{A} \frac{g_{i} - T}{T} \right)$$

In this PR, we are increasing the value of $A$, the base fee change denominator. Therefore, fee update will be much more stable(not moving much). Users/Wallets will experience less failure of transactions because the fees got less volatile. 

## Testing

Unit tests added. In this PR, I will verify the values manually in this description. Here are the test cases:
```go
tests := []struct {
		parentBaseFee   int64
		parentGasLimit  uint64
		parentGasUsed   uint64
		expectedBaseFee int64
		postCanyon      bool
	}{
		{params.InitialBaseFee, 30_000_000, 5_000_000, params.InitialBaseFee, false}, // usage == target
		{params.InitialBaseFee, 30_000_000, 4_000_000, 996000000, false},             // usage below target
		{params.InitialBaseFee, 30_000_000, 10_000_000, 1020000000, false},           // usage above target
		{params.InitialBaseFee, 30_000_000, 5_000_000, params.InitialBaseFee, true},  // usage == target
		{params.InitialBaseFee, 30_000_000, 4_000_000, 999200000, true},              // usage below target
		{params.InitialBaseFee, 30_000_000, 10_000_000, 1004000000, true},            // usage above target
	}
```
`params.InitialBaseFee == 1_000_000_000`
`T = parentGasTarget = parent.GasLimit / ElasticityMultiplier = 30_000_000 / 6 = 5_000_000`

For {2,3,5,6}th sub task, 
Before Canyon: `A = 50`
- 2: `1_000_000_000 * (1 + (1 / 50) * (5_000_000 - 5_000_000) / 5_000_000) == 1_000_000_000`
- 3: `1_000_000_000 * (1 + (1 / 50) * (4_000_000 - 5_000_000) / 5_000_000) == 996_000_000`
Canyon: `A = 250`
- 5: `1_000_000_000 * (1 + (1 / 250) * (4_000_000 - 5_000_000) / 5_000_000) == 999_200_000`
- 6: `1_000_000_000 * (1 + (1 / 250) * (10_000_000 - 5_000_000) / 5_000_000) == 1_004_000_000`

## Misc

- Pin erigon-lib as https://github.com/testinprod-io/erigon-lib/pull/26/commits/b93d9d11c10ff4a30da037e55ca9e6b54055bac3, part of https://github.com/testinprod-io/erigon-lib/pull/26


