### PR TITLE
[Canyon Hard Fork] Receipt Root Deposit Nonce Hashing Bug Fix

### DIFF
--- a/cmd/rpcdaemon/commands/erigon_block.go
+++ b/cmd/rpcdaemon/commands/erigon_block.go
@@ -190,8 +190,8 @@ func buildBlockResponse(br services.FullBlockReader, db kv.Tx, blockNum uint64, 
 		additionalFields["totalDifficulty"] = (*hexutil.Big)(td)
 	}
 
-	depositNonces := rawdb.ReadDepositNonces(db, blockNum)
-	response, err := ethapi.RPCMarshalBlockEx(block, true, fullTx, nil, common.Hash{}, additionalFields, depositNonces)
+	receipts := rawdb.ReadRawReceipts(db, blockNum)
+	response, err := ethapi.RPCMarshalBlockEx(block, true, fullTx, nil, common.Hash{}, additionalFields, receipts)
 
 	if err == nil && rpc.BlockNumber(block.NumberU64()) == rpc.PendingBlockNumber {
 		// Pending blocks need to nil out a few fields

--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -403,12 +403,14 @@ type RPCTransaction struct {
 	SourceHash *common.Hash `json:"sourceHash,omitempty"`
 	Mint       *hexutil.Big `json:"mint,omitempty"`
 	IsSystemTx *bool        `json:"isSystemTx,omitempty"`
+	// deposit-tx post-Canyon only
+	DepositReceiptVersion *hexutil.Uint64 `json:"depositReceiptVersion,omitempty"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
 func newRPCTransaction(tx types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int,
-	depositNonce *uint64) *RPCTransaction {
+	receipt *types.Receipt) *RPCTransaction {
 	// Determine the signer. For replay-protected transactions, use the most permissive
 	// signer, because we assume that signers are backwards-compatible with old
 	// transactions. For non-protected transactions, the homestead signer signer is used
@@ -464,8 +466,12 @@ func newRPCTransaction(tx types.Transaction, blockHash common.Hash, blockNumber 
 		if t.IsSystemTransaction {
 			result.IsSystemTx = &t.IsSystemTransaction
 		}
-		if depositNonce != nil {
-			result.Nonce = hexutil.Uint64(*depositNonce)
+		if receipt != nil && receipt.DepositNonce != nil {
+			result.Nonce = hexutil.Uint64(*receipt.DepositNonce)
+			if receipt.DepositReceiptVersion != nil {
+				result.DepositReceiptVersion = new(hexutil.Uint64)
+				*result.DepositReceiptVersion = hexutil.Uint64(*receipt.DepositReceiptVersion)
+			}
 		}
 		result.GasPrice = (*hexutil.Big)(common.Big0)
 		// must contain v, r, s values for backwards compatibility.

--- a/cmd/rpcdaemon/commands/eth_block.go
+++ b/cmd/rpcdaemon/commands/eth_block.go
@@ -231,8 +231,8 @@ func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber
 		}
 	}
 
-	depositNonces := rawdb.ReadDepositNonces(tx, b.NumberU64())
-	response, err := ethapi.RPCMarshalBlockEx(b, true, fullTx, borTx, borTxHash, additionalFields, depositNonces)
+	receipts := rawdb.ReadRawReceipts(tx, b.NumberU64())
+	response, err := ethapi.RPCMarshalBlockEx(b, true, fullTx, borTx, borTxHash, additionalFields, receipts)
 	if err == nil && number == rpc.PendingBlockNumber {
 		// Pending blocks need to nil out a few fields
 		for _, field := range []string{"hash", "nonce", "miner"} {
@@ -291,8 +291,8 @@ func (api *APIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc.BlockNu
 		}
 	}
 
-	depositNonces := rawdb.ReadDepositNonces(tx, number)
-	response, err := ethapi.RPCMarshalBlockEx(block, true, fullTx, borTx, borTxHash, additionalFields, depositNonces)
+	receipts := rawdb.ReadRawReceipts(tx, number)
+	response, err := ethapi.RPCMarshalBlockEx(block, true, fullTx, borTx, borTxHash, additionalFields, receipts)
 
 	if chainConfig.Bor != nil {
 		response["miner"], _ = ecrecover(block.Header(), chainConfig.Bor)

--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -773,8 +773,13 @@ func marshalReceipt(receipt *types.Receipt, txn types.Transaction, chainConfig *
 			fields["l1GasUsed"] = hexutil.Big(*receipt.L1GasUsed)
 			fields["l1Fee"] = hexutil.Big(*receipt.L1Fee)
 			fields["l1FeeScalar"] = receipt.FeeScalar
-		} else if receipt.DepositNonce != nil {
-			fields["depositNonce"] = hexutil.Uint64(*receipt.DepositNonce)
+		} else {
+			if receipt.DepositNonce != nil {
+				fields["depositNonce"] = hexutil.Uint64(*receipt.DepositNonce)
+			}
+			if receipt.DepositReceiptVersion != nil {
+				fields["depositReceiptVersion"] = hexutil.Uint64(*receipt.DepositReceiptVersion)
+			}
 		}
 	}
 

--- a/cmd/rpcdaemon/commands/eth_txs.go
+++ b/cmd/rpcdaemon/commands/eth_txs.go
@@ -86,12 +86,11 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, txnHash common.Has
 		}
 
 		if chainConfig.IsOptimism() {
-			depositNonces := rawdb.ReadDepositNonces(tx, block.NumberU64())
-			if txnIndex >= uint64(len(depositNonces)) {
-				return nil, fmt.Errorf("depositNonce for tx %x not found", txnHash)
-			} else {
-				return newRPCTransaction(txn, blockHash, blockNum, txnIndex, baseFee, depositNonces[txnIndex]), nil
+			receipts := rawdb.ReadRawReceipts(tx, block.NumberU64())
+			if len(receipts) <= int(txnIndex) {
+				return nil, fmt.Errorf("block has less receipts than expected: %d <= %d, block: %d", len(receipts), int(txnIndex), blockNum)
 			}
+			return newRPCTransaction(txn, blockHash, blockNum, txnIndex, baseFee, receipts[txnIndex]), nil
 		}
 		return newRPCTransaction(txn, blockHash, blockNum, txnIndex, baseFee, nil), nil
 	}
@@ -209,12 +208,11 @@ func (api *APIImpl) GetTransactionByBlockHashAndIndex(ctx context.Context, block
 	}
 
 	if chainConfig.IsOptimism() {
-		depositNonces := rawdb.ReadDepositNonces(tx, block.NumberU64())
-		if uint64(txIndex) >= uint64(len(depositNonces)) {
-			return nil, fmt.Errorf("depositNonce for tx %x not found", txs[txIndex].Hash())
-		} else {
-			return newRPCTransaction(txs[txIndex], block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee(), depositNonces[txIndex]), nil
+		receipts := rawdb.ReadRawReceipts(tx, block.NumberU64())
+		if len(receipts) <= int(txIndex) {
+			return nil, fmt.Errorf("block has less receipts than expected: %d <= %d, block: %d", len(receipts), int(txIndex), block.NumberU64())
 		}
+		return newRPCTransaction(txs[txIndex], block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee(), receipts[txIndex]), nil
 	}
 	return newRPCTransaction(txs[txIndex], block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee(), nil), nil
 }
@@ -280,12 +278,11 @@ func (api *APIImpl) GetTransactionByBlockNumberAndIndex(ctx context.Context, blo
 		return newRPCBorTransaction(borTx, derivedBorTxHash, block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee(), chainConfig.ChainID), nil
 	}
 	if chainConfig.IsOptimism() {
-		depositNonces := rawdb.ReadDepositNonces(tx, blockNum)
-		if uint64(txIndex) >= uint64(len(depositNonces)) {
-			return nil, fmt.Errorf("depositNonce for tx %x not found", txs[txIndex].Hash())
-		} else {
-			return newRPCTransaction(txs[txIndex], block.Hash(), blockNum, uint64(txIndex), block.BaseFee(), depositNonces[txIndex]), nil
+		receipts := rawdb.ReadRawReceipts(tx, block.NumberU64())
+		if len(receipts) <= int(txIndex) {
+			return nil, fmt.Errorf("block has less receipts than expected: %d <= %d, block: %d", len(receipts), int(txIndex), block.NumberU64())
 		}
+		return newRPCTransaction(txs[txIndex], block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee(), receipts[txIndex]), nil
 	}
 	return newRPCTransaction(txs[txIndex], block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee(), nil), nil
 }

--- a/cmd/rpcdaemon/commands/eth_uncles.go
+++ b/cmd/rpcdaemon/commands/eth_uncles.go
@@ -46,8 +46,8 @@ func (api *APIImpl) GetUncleByBlockNumberAndIndex(ctx context.Context, number rp
 		return nil, nil
 	}
 	uncle := types.NewBlockWithHeader(uncles[index])
-	depositNonces := rawdb.ReadDepositNonces(tx, blockNum)
-	return ethapi.RPCMarshalBlock(uncle, false, false, additionalFields, depositNonces)
+	receipts := rawdb.ReadRawReceipts(tx, blockNum)
+	return ethapi.RPCMarshalBlock(uncle, false, false, additionalFields, receipts)
 }
 
 // GetUncleByBlockHashAndIndex implements eth_getUncleByBlockHashAndIndex. Returns information about an uncle given a block's hash and the index of the uncle.
@@ -79,8 +79,8 @@ func (api *APIImpl) GetUncleByBlockHashAndIndex(ctx context.Context, hash common
 		return nil, nil
 	}
 	uncle := types.NewBlockWithHeader(uncles[index])
-	depositNonces := rawdb.ReadDepositNonces(tx, number)
-	return ethapi.RPCMarshalBlock(uncle, false, false, additionalFields, depositNonces)
+	receipts := rawdb.ReadRawReceipts(tx, number)
+	return ethapi.RPCMarshalBlock(uncle, false, false, additionalFields, receipts)
 }
 
 // GetUncleCountByBlockNumber implements eth_getUncleCountByBlockNumber. Returns the number of uncles in the block, if any.

--- a/cmd/rpcdaemon/commands/graphql_api.go
+++ b/cmd/rpcdaemon/commands/graphql_api.go
@@ -116,8 +116,8 @@ func (api *GraphQLAPIImpl) delegateGetBlockByNumber(tx kv.Tx, b *types.Block, nu
 		return nil, err
 	}
 	additionalFields := make(map[string]interface{})
-	depositNonces := rawdb.ReadDepositNonces(tx, uint64(number.Int64()))
-	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields, depositNonces)
+	receipts := rawdb.ReadRawReceipts(tx, uint64(number.Int64()))
+	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields, receipts)
 	if !inclTx {
 		delete(response, "transactions") // workaround for https://github.com/ledgerwatch/erigon/issues/4989#issuecomment-1218415666
 	}

--- a/cmd/rpcdaemon/commands/otterscan_api.go
+++ b/cmd/rpcdaemon/commands/otterscan_api.go
@@ -523,8 +523,8 @@ func (api *OtterscanAPIImpl) searchTransactionsBeforeV3(tx kv.TemporalTx, ctx co
 		var receipt *types.Receipt
 		if chainConfig.IsOptimism() {
 			receipts := rawdb.ReadRawReceipts(tx, blockNum)
-			if len(receipts) <= int(txIndex) {
-				return nil, fmt.Errorf("block has less receipts than expected: %d <= %d, block: %d", len(receipts), int(txIndex), blockNum)
+			if len(receipts) <= txIndex {
+				return nil, fmt.Errorf("block has less receipts than expected: %d <= %d, block: %d", len(receipts), txIndex, blockNum)
 			}
 			receipt = receipts[txIndex]
 		}

--- a/cmd/rpcdaemon/commands/otterscan_api.go
+++ b/cmd/rpcdaemon/commands/otterscan_api.go
@@ -520,18 +520,17 @@ func (api *OtterscanAPIImpl) searchTransactionsBeforeV3(tx kv.TemporalTx, ctx co
 			return nil, err
 		}
 		var rpcTx *RPCTransaction
+		var receipt *types.Receipt
 		if chainConfig.IsOptimism() {
-			depositNonces := rawdb.ReadDepositNonces(tx, blockNum)
-			if txIndex >= len(depositNonces) {
-				return nil, fmt.Errorf("depositNonce for tx %x not found", txn.Hash())
-			} else {
-				rpcTx = newRPCTransaction(txn, blockHash, blockNum, uint64(txIndex), header.BaseFee, depositNonces[txIndex])
+			receipts := rawdb.ReadRawReceipts(tx, blockNum)
+			if len(receipts) <= int(txIndex) {
+				return nil, fmt.Errorf("block has less receipts than expected: %d <= %d, block: %d", len(receipts), int(txIndex), blockNum)
 			}
-		} else {
-			rpcTx = newRPCTransaction(txn, blockHash, blockNum, uint64(txIndex), header.BaseFee, nil)
+			receipt = receipts[txIndex]
 		}
+		rpcTx = newRPCTransaction(txn, blockHash, blockNum, uint64(txIndex), header.BaseFee, receipt)
 		txs = append(txs, rpcTx)
-		receipt := &types.Receipt{
+		receipt = &types.Receipt{
 			Type: txn.Type(), CumulativeGasUsed: res.UsedGas,
 			TransactionIndex: uint(txIndex),
 			BlockNumber:      header.Number, BlockHash: blockHash, Logs: rawLogs,
@@ -677,8 +676,8 @@ func (api *OtterscanAPIImpl) delegateGetBlockByNumber(tx kv.Tx, b *types.Block, 
 		return nil, err
 	}
 	additionalFields := make(map[string]interface{})
-	depositNonces := rawdb.ReadDepositNonces(tx, uint64(number.Int64()))
-	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields, depositNonces)
+	receipts := rawdb.ReadRawReceipts(tx, uint64(number.Int64()))
+	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields, receipts)
 	if !inclTx {
 		delete(response, "transactions") // workaround for https://github.com/ledgerwatch/erigon/issues/4989#issuecomment-1218415666
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -22,10 +22,11 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"github.com/ledgerwatch/erigon-lib/chain"
 	"math"
 	"math/big"
 	"time"
+
+	"github.com/ledgerwatch/erigon-lib/chain"
 
 	"github.com/gballet/go-verkle"
 	common2 "github.com/ledgerwatch/erigon-lib/common"
@@ -849,18 +850,6 @@ func ReadReceipts(config *chain.Config, db kv.Tx, block *types.Block, senders []
 		return nil
 	}
 	return receipts
-}
-
-func ReadDepositNonces(db kv.Tx, blockNumber uint64) []*uint64 {
-	receipts := ReadRawReceipts(db, blockNumber)
-	if receipts == nil {
-		return nil
-	}
-	depositNonces := make([]*uint64, len(receipts))
-	for i, r := range receipts {
-		depositNonces[i] = r.DepositNonce
-	}
-	return depositNonces
 }
 
 // WriteReceipts stores all the transaction receipts belonging to a block.

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -91,9 +91,14 @@ func applyTransaction(config *chain.Config, engine consensus.EngineReader, gp *G
 		receipt.GasUsed = result.UsedGas
 
 		if msg.IsDepositTx() && config.IsOptimismRegolith(evm.Context().Time) {
-			// The actual nonce for deposit transactions is only recorded from Regolith onwards.
-			// Before the Regolith fork the DepositNonce must remain nil
+			// The actual nonce for deposit transactions is only recorded from Regolith onwards and
+			// otherwise must be nil.
 			receipt.DepositNonce = &nonce
+
+			if config.IsOptimismCanyon(evm.Context().Time) {
+				receipt.DepositReceiptVersion = new(uint64)
+				*receipt.DepositReceiptVersion = types.CanyonDepositReceiptVersion
+			}
 		}
 
 		// if the transaction created a contract, store the creation address in the receipt.

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -7,9 +7,8 @@ import (
 	"errors"
 	"math/big"
 
-	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
-
 	"github.com/ledgerwatch/erigon/common/hexutil"
 )
 
@@ -18,18 +17,24 @@ var _ = (*receiptMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (r Receipt) MarshalJSON() ([]byte, error) {
 	type Receipt struct {
-		Type              hexutil.Uint64    `json:"type,omitempty"`
-		PostState         hexutility.Bytes  `json:"root"`
-		Status            hexutil.Uint64    `json:"status"`
-		CumulativeGasUsed hexutil.Uint64    `json:"cumulativeGasUsed" gencodec:"required"`
-		Bloom             Bloom             `json:"logsBloom"         gencodec:"required"`
-		Logs              []*Log            `json:"logs"              gencodec:"required"`
-		TxHash            libcommon.Hash    `json:"transactionHash" gencodec:"required"`
-		ContractAddress   libcommon.Address `json:"contractAddress"`
-		GasUsed           hexutil.Uint64    `json:"gasUsed" gencodec:"required"`
-		BlockHash         libcommon.Hash    `json:"blockHash,omitempty"`
-		BlockNumber       *hexutil.Big      `json:"blockNumber,omitempty"`
-		TransactionIndex  hexutil.Uint      `json:"transactionIndex"`
+		Type                  hexutil.Uint64   `json:"type,omitempty"`
+		PostState             hexutility.Bytes `json:"root" codec:"1"`
+		Status                hexutil.Uint64   `json:"status" codec:"2"`
+		CumulativeGasUsed     hexutil.Uint64   `json:"cumulativeGasUsed" gencodec:"required" codec:"3"`
+		Bloom                 Bloom            `json:"logsBloom"         gencodec:"required" codec:"-"`
+		Logs                  Logs             `json:"logs"              gencodec:"required" codec:"-"`
+		TxHash                common.Hash      `json:"transactionHash" gencodec:"required" codec:"-"`
+		ContractAddress       common.Address   `json:"contractAddress" codec:"-"`
+		GasUsed               hexutil.Uint64   `json:"gasUsed" gencodec:"required" codec:"-"`
+		BlockHash             common.Hash      `json:"blockHash,omitempty" codec:"-"`
+		BlockNumber           *hexutil.Big     `json:"blockNumber,omitempty" codec:"-"`
+		TransactionIndex      hexutil.Uint     `json:"transactionIndex" codec:"-"`
+		L1GasPrice            *hexutil.Big     `json:"l1GasPrice,omitempty"`
+		L1GasUsed             *hexutil.Big     `json:"l1GasUsed,omitempty"`
+		L1Fee                 *hexutil.Big     `json:"l1Fee,omitempty"`
+		FeeScalar             *big.Float       `json:"l1FeeScalar,omitempty"`
+		DepositNonce          *hexutil.Uint64  `json:"depositNonce,omitempty"`
+		DepositReceiptVersion *hexutil.Uint64  `json:"depositReceiptVersion,omitempty"`
 	}
 	var enc Receipt
 	enc.Type = hexutil.Uint64(r.Type)
@@ -44,24 +49,36 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.BlockHash = r.BlockHash
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
 	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
+	enc.L1GasPrice = (*hexutil.Big)(r.L1GasPrice)
+	enc.L1GasUsed = (*hexutil.Big)(r.L1GasUsed)
+	enc.L1Fee = (*hexutil.Big)(r.L1Fee)
+	enc.FeeScalar = r.FeeScalar
+	enc.DepositNonce = (*hexutil.Uint64)(r.DepositNonce)
+	enc.DepositReceiptVersion = (*hexutil.Uint64)(r.DepositReceiptVersion)
 	return json.Marshal(&enc)
 }
 
 // UnmarshalJSON unmarshals from JSON.
 func (r *Receipt) UnmarshalJSON(input []byte) error {
 	type Receipt struct {
-		Type              *hexutil.Uint64    `json:"type,omitempty"`
-		PostState         *hexutility.Bytes  `json:"root"`
-		Status            *hexutil.Uint64    `json:"status"`
-		CumulativeGasUsed *hexutil.Uint64    `json:"cumulativeGasUsed" gencodec:"required"`
-		Bloom             *Bloom             `json:"logsBloom"         gencodec:"required"`
-		Logs              []*Log             `json:"logs"              gencodec:"required"`
-		TxHash            *libcommon.Hash    `json:"transactionHash" gencodec:"required"`
-		ContractAddress   *libcommon.Address `json:"contractAddress"`
-		GasUsed           *hexutil.Uint64    `json:"gasUsed" gencodec:"required"`
-		BlockHash         *libcommon.Hash    `json:"blockHash,omitempty"`
-		BlockNumber       *hexutil.Big       `json:"blockNumber,omitempty"`
-		TransactionIndex  *hexutil.Uint      `json:"transactionIndex"`
+		Type                  *hexutil.Uint64   `json:"type,omitempty"`
+		PostState             *hexutility.Bytes `json:"root" codec:"1"`
+		Status                *hexutil.Uint64   `json:"status" codec:"2"`
+		CumulativeGasUsed     *hexutil.Uint64   `json:"cumulativeGasUsed" gencodec:"required" codec:"3"`
+		Bloom                 *Bloom            `json:"logsBloom"         gencodec:"required" codec:"-"`
+		Logs                  *Logs             `json:"logs"              gencodec:"required" codec:"-"`
+		TxHash                *common.Hash      `json:"transactionHash" gencodec:"required" codec:"-"`
+		ContractAddress       *common.Address   `json:"contractAddress" codec:"-"`
+		GasUsed               *hexutil.Uint64   `json:"gasUsed" gencodec:"required" codec:"-"`
+		BlockHash             *common.Hash      `json:"blockHash,omitempty" codec:"-"`
+		BlockNumber           *hexutil.Big      `json:"blockNumber,omitempty" codec:"-"`
+		TransactionIndex      *hexutil.Uint     `json:"transactionIndex" codec:"-"`
+		L1GasPrice            *hexutil.Big      `json:"l1GasPrice,omitempty"`
+		L1GasUsed             *hexutil.Big      `json:"l1GasUsed,omitempty"`
+		L1Fee                 *hexutil.Big      `json:"l1Fee,omitempty"`
+		FeeScalar             *big.Float        `json:"l1FeeScalar,omitempty"`
+		DepositNonce          *hexutil.Uint64   `json:"depositNonce,omitempty"`
+		DepositReceiptVersion *hexutil.Uint64   `json:"depositReceiptVersion,omitempty"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -87,7 +104,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	if dec.Logs == nil {
 		return errors.New("missing required field 'logs' for Receipt")
 	}
-	r.Logs = dec.Logs
+	r.Logs = *dec.Logs
 	if dec.TxHash == nil {
 		return errors.New("missing required field 'transactionHash' for Receipt")
 	}
@@ -107,6 +124,24 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	}
 	if dec.TransactionIndex != nil {
 		r.TransactionIndex = uint(*dec.TransactionIndex)
+	}
+	if dec.L1GasPrice != nil {
+		r.L1GasPrice = (*big.Int)(dec.L1GasPrice)
+	}
+	if dec.L1GasUsed != nil {
+		r.L1GasUsed = (*big.Int)(dec.L1GasUsed)
+	}
+	if dec.L1Fee != nil {
+		r.L1Fee = (*big.Int)(dec.L1Fee)
+	}
+	if dec.FeeScalar != nil {
+		r.FeeScalar = dec.FeeScalar
+	}
+	if dec.DepositNonce != nil {
+		r.DepositNonce = (*uint64)(dec.DepositNonce)
+	}
+	if dec.DepositReceiptVersion != nil {
+		r.DepositReceiptVersion = (*uint64)(dec.DepositReceiptVersion)
 	}
 	return nil
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -105,11 +105,13 @@ type receiptMarshaling struct {
 	BlockNumber       *hexutil.Big
 	TransactionIndex  hexutil.Uint
 
-	// Optimism: extend receipts with their L1 price (if a rollup tx)
-	L1GasPrice *hexutil.Big
-	L1GasUsed  *hexutil.Big
-	L1Fee      *hexutil.Big
-	FeeScalar  *big.Float
+	// Optimism
+	L1GasPrice            *hexutil.Big
+	L1GasUsed             *hexutil.Big
+	L1Fee                 *hexutil.Big
+	FeeScalar             *big.Float
+	DepositNonce          *hexutil.Uint64
+	DepositReceiptVersion *hexutil.Uint64
 }
 
 // receiptRLP is the consensus encoding of a receipt.

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -515,10 +515,11 @@ type Receipts []*Receipt
 // Len returns the number of receipts in this list.
 func (rs Receipts) Len() int { return len(rs) }
 
-// EncodeIndex encodes the i'th receipt to w. For DepositTxType receipts with non-nil DepositNonce
-// but nil DepositReceiptVersion, the output will differ than calling r.MarshalBinary(); this
-// behavior difference should not be changed to preserve backwards compatibility of receipt-root
-// hash computation.
+
+// EncodeIndex encodes the i'th receipt to w.
+// During post-regolith and pre-Canyon, DepositNonce was not included when encoding for hashing.
+// Canyon adds DepositReceiptVersion to preserve backwards compatibility for pre-Canyon, and
+// for correct receipt-root hash computation.
 func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	r := rs[i]
 	data := &receiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -385,7 +385,10 @@ func (r *Receipt) Copy() *Receipt {
 	txHash := libcommon.BytesToHash(r.TxHash.Bytes())
 	contractAddress := libcommon.BytesToAddress(r.ContractAddress.Bytes())
 	blockHash := libcommon.BytesToHash(r.BlockHash.Bytes())
-	blockNumber := big.NewInt(0).Set(r.BlockNumber)
+	var blockNumber *big.Int
+	if r.BlockNumber != nil {
+		blockNumber = big.NewInt(0).Set(r.BlockNumber)
+	}
 
 	return &Receipt{
 		Type:                  r.Type,
@@ -514,7 +517,6 @@ type Receipts []*Receipt
 
 // Len returns the number of receipts in this list.
 func (rs Receipts) Len() int { return len(rs) }
-
 
 // EncodeIndex encodes the i'th receipt to w.
 // During post-regolith and pre-Canyon, DepositNonce was not included when encoding for hashing.

--- a/core/types/receipt_codecgen_gen.go
+++ b/core/types/receipt_codecgen_gen.go
@@ -69,7 +69,8 @@ func (x *Receipt) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyn9 bool = x.L1Fee == nil
 			var yyn10 bool = x.FeeScalar == nil
 			var yyn11 bool = x.DepositNonce == nil
-			z.EncWriteArrayStart(9)
+			var yyn12 bool = x.DepositReceiptVersion == nil
+			z.EncWriteArrayStart(10)
 			z.EncWriteArrayElem()
 			r.EncodeUint(uint64(x.Type))
 			z.EncWriteArrayElem()
@@ -131,8 +132,16 @@ func (x *Receipt) CodecEncodeSelf(e *codec1978.Encoder) {
 				r.EncodeNil()
 			} else {
 				z.EncWriteArrayElem()
-				yy20 := *x.DepositNonce
-				r.EncodeUint(uint64(yy20))
+				yy21 := *x.DepositNonce
+				r.EncodeUint(uint64(yy21))
+			}
+			if yyn12 {
+				z.EncWriteArrayElem()
+				r.EncodeNil()
+			} else {
+				z.EncWriteArrayElem()
+				yy23 := *x.DepositReceiptVersion
+				r.EncodeUint(uint64(yy23))
 			}
 			z.EncWriteArrayEnd()
 		}
@@ -266,6 +275,17 @@ func (x *Receipt) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				}
 				*x.DepositNonce = (uint64)(r.DecodeUint64())
 			}
+		case "DepositReceiptVersion":
+			if r.TryNil() {
+				if x.DepositReceiptVersion != nil { // remove the if-true
+					x.DepositReceiptVersion = nil
+				}
+			} else {
+				if x.DepositReceiptVersion == nil {
+					x.DepositReceiptVersion = new(uint64)
+				}
+				*x.DepositReceiptVersion = (uint64)(r.DecodeUint64())
+			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3)
 		} // end switch yys3
@@ -276,64 +296,64 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer2
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj19 int
-	var yyb19 bool
-	var yyhl19 bool = l >= 0
-	yyj19++
-	if yyhl19 {
-		yyb19 = yyj19 > l
+	var yyj21 int
+	var yyb21 bool
+	var yyhl21 bool = l >= 0
+	yyj21++
+	if yyhl21 {
+		yyb21 = yyj21 > l
 	} else {
-		yyb19 = z.DecCheckBreak()
+		yyb21 = z.DecCheckBreak()
 	}
-	if yyb19 {
+	if yyb21 {
 		z.DecReadArrayEnd()
 		return
 	}
 	z.DecReadArrayElem()
 	x.Type = (uint8)(z.C.UintV(r.DecodeUint64(), 8))
-	yyj19++
-	if yyhl19 {
-		yyb19 = yyj19 > l
+	yyj21++
+	if yyhl21 {
+		yyb21 = yyj21 > l
 	} else {
-		yyb19 = z.DecCheckBreak()
+		yyb21 = z.DecCheckBreak()
 	}
-	if yyb19 {
+	if yyb21 {
 		z.DecReadArrayEnd()
 		return
 	}
 	z.DecReadArrayElem()
 	x.PostState = r.DecodeBytes(([]byte)(x.PostState), false)
-	yyj19++
-	if yyhl19 {
-		yyb19 = yyj19 > l
+	yyj21++
+	if yyhl21 {
+		yyb21 = yyj21 > l
 	} else {
-		yyb19 = z.DecCheckBreak()
+		yyb21 = z.DecCheckBreak()
 	}
-	if yyb19 {
+	if yyb21 {
 		z.DecReadArrayEnd()
 		return
 	}
 	z.DecReadArrayElem()
 	x.Status = (uint64)(r.DecodeUint64())
-	yyj19++
-	if yyhl19 {
-		yyb19 = yyj19 > l
+	yyj21++
+	if yyhl21 {
+		yyb21 = yyj21 > l
 	} else {
-		yyb19 = z.DecCheckBreak()
+		yyb21 = z.DecCheckBreak()
 	}
-	if yyb19 {
+	if yyb21 {
 		z.DecReadArrayEnd()
 		return
 	}
 	z.DecReadArrayElem()
 	x.CumulativeGasUsed = (uint64)(r.DecodeUint64())
-	yyj19++
-	if yyhl19 {
-		yyb19 = yyj19 > l
+	yyj21++
+	if yyhl21 {
+		yyb21 = yyj21 > l
 	} else {
-		yyb19 = z.DecCheckBreak()
+		yyb21 = z.DecCheckBreak()
 	}
-	if yyb19 {
+	if yyb21 {
 		z.DecReadArrayEnd()
 		return
 	}
@@ -352,13 +372,13 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 			z.DecFallback(x.L1GasPrice, false)
 		}
 	}
-	yyj19++
-	if yyhl19 {
-		yyb19 = yyj19 > l
+	yyj21++
+	if yyhl21 {
+		yyb21 = yyj21 > l
 	} else {
-		yyb19 = z.DecCheckBreak()
+		yyb21 = z.DecCheckBreak()
 	}
-	if yyb19 {
+	if yyb21 {
 		z.DecReadArrayEnd()
 		return
 	}
@@ -377,13 +397,13 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 			z.DecFallback(x.L1GasUsed, false)
 		}
 	}
-	yyj19++
-	if yyhl19 {
-		yyb19 = yyj19 > l
+	yyj21++
+	if yyhl21 {
+		yyb21 = yyj21 > l
 	} else {
-		yyb19 = z.DecCheckBreak()
+		yyb21 = z.DecCheckBreak()
 	}
-	if yyb19 {
+	if yyb21 {
 		z.DecReadArrayEnd()
 		return
 	}
@@ -402,13 +422,13 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 			z.DecFallback(x.L1Fee, false)
 		}
 	}
-	yyj19++
-	if yyhl19 {
-		yyb19 = yyj19 > l
+	yyj21++
+	if yyhl21 {
+		yyb21 = yyj21 > l
 	} else {
-		yyb19 = z.DecCheckBreak()
+		yyb21 = z.DecCheckBreak()
 	}
-	if yyb19 {
+	if yyb21 {
 		z.DecReadArrayEnd()
 		return
 	}
@@ -427,13 +447,13 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 			z.DecFallback(x.FeeScalar, false)
 		}
 	}
-	yyj19++
-	if yyhl19 {
-		yyb19 = yyj19 > l
+	yyj21++
+	if yyhl21 {
+		yyb21 = yyj21 > l
 	} else {
-		yyb19 = z.DecCheckBreak()
+		yyb21 = z.DecCheckBreak()
 	}
-	if yyb19 {
+	if yyb21 {
 		z.DecReadArrayEnd()
 		return
 	}
@@ -448,18 +468,39 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		*x.DepositNonce = (uint64)(r.DecodeUint64())
 	}
-	for {
-		yyj19++
-		if yyhl19 {
-			yyb19 = yyj19 > l
-		} else {
-			yyb19 = z.DecCheckBreak()
+	yyj21++
+	if yyhl21 {
+		yyb21 = yyj21 > l
+	} else {
+		yyb21 = z.DecCheckBreak()
+	}
+	if yyb21 {
+		z.DecReadArrayEnd()
+		return
+	}
+	z.DecReadArrayElem()
+	if r.TryNil() {
+		if x.DepositReceiptVersion != nil { // remove the if-true
+			x.DepositReceiptVersion = nil
 		}
-		if yyb19 {
+	} else {
+		if x.DepositReceiptVersion == nil {
+			x.DepositReceiptVersion = new(uint64)
+		}
+		*x.DepositReceiptVersion = (uint64)(r.DecodeUint64())
+	}
+	for {
+		yyj21++
+		if yyhl21 {
+			yyb21 = yyj21 > l
+		} else {
+			yyb21 = z.DecCheckBreak()
+		}
+		if yyb21 {
 			break
 		}
 		z.DecReadArrayElem()
-		z.DecStructFieldNotFound(yyj19-1, "")
+		z.DecStructFieldNotFound(yyj21-1, "")
 	}
 }
 

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -559,7 +559,7 @@ func TestReceiptEncodeIndexBugIsEnshrined(t *testing.T) {
 	// Check that a post-Regolith, pre-Canyon receipt produces no difference between
 	// receipts having different depositNonce
 	buf := new(bytes.Buffer)
-	receipts := Receipts{depositReceiptWithNonce}
+	receipts := Receipts{depositReceiptWithNonce.Copy()}
 	receipts.EncodeIndex(0, buf)
 	indexBytesBefore := buf.Bytes()
 
@@ -577,14 +577,14 @@ func TestReceiptEncodeIndexBugIsEnshrined(t *testing.T) {
 	buf3 := new(bytes.Buffer)
 	receipts[0].Type = eip1559Receipt.Type
 	receipts.EncodeIndex(0, buf3)
-	indexBytesNonDeposit := buf3.Bytes()
+	indexBytesNoDeposit := buf3.Bytes()
 
-	require.NotEqual(t, indexBytesBefore[0], indexBytesNonDeposit[0])
-	require.Equal(t, indexBytesBefore[1:], indexBytesNonDeposit[1:])
+	require.NotEqual(t, indexBytesBefore[0], indexBytesNoDeposit[0])
+	require.Equal(t, indexBytesBefore[1:], indexBytesNoDeposit[1:])
 
 	// Check that post-canyon changes the hash compared to pre-Canyon
 	buf4 := new(bytes.Buffer)
-	receipts = Receipts{depositReceiptWithNonceAndVersion}
+	receipts = Receipts{depositReceiptWithNonceAndVersion.Copy()}
 	receipts.EncodeIndex(0, buf4)
 	indexBytesCanyon := buf4.Bytes()
 	require.NotEqual(t, indexBytesBefore[1:], indexBytesCanyon[1:])

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -20,11 +20,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"math"
 	"math/big"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/holiman/uint256"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
@@ -106,9 +107,30 @@ var (
 	}
 	nonce                   = uint64(1234)
 	depositReceiptWithNonce = &Receipt{
-		Status:            ReceiptStatusFailed,
-		CumulativeGasUsed: 1,
-		DepositNonce:      &nonce,
+		Status:                ReceiptStatusFailed,
+		CumulativeGasUsed:     1,
+		DepositNonce:          &nonce,
+		DepositReceiptVersion: nil,
+		Logs: []*Log{
+			{
+				Address: libcommon.BytesToAddress([]byte{0x11}),
+				Topics:  []libcommon.Hash{libcommon.HexToHash("dead"), libcommon.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+			{
+				Address: libcommon.BytesToAddress([]byte{0x01, 0x11}),
+				Topics:  []libcommon.Hash{libcommon.HexToHash("dead"), libcommon.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+		},
+		Type: DepositTxType,
+	}
+	version                           = CanyonDepositReceiptVersion
+	depositReceiptWithNonceAndVersion = &Receipt{
+		Status:                ReceiptStatusFailed,
+		CumulativeGasUsed:     1,
+		DepositNonce:          &nonce,
+		DepositReceiptVersion: &version,
 		Logs: []*Log{
 			{
 				Address: libcommon.BytesToAddress([]byte{0x11}),
@@ -253,8 +275,15 @@ func TestDeriveFields(t *testing.T) {
 			Value: uint256.NewInt(3),
 			Gas:   4,
 		},
+		&DepositTx{
+			To:    nil, // contract creation
+			Value: uint256.NewInt(6),
+			Gas:   5,
+		},
 	}
 	depNonce := uint64(7)
+	depNonce2 := uint64(8)
+	canyonDepositReceiptVersion := CanyonDepositReceiptVersion
 	// Create the corresponding receipts
 	receipts := Receipts{
 		&Receipt{
@@ -299,10 +328,49 @@ func TestDeriveFields(t *testing.T) {
 				{Address: libcommon.BytesToAddress([]byte{0x33})},
 				{Address: libcommon.BytesToAddress([]byte{0x03, 0x33})},
 			},
-			TxHash:          txs[3].Hash(),
-			ContractAddress: libcommon.BytesToAddress([]byte{0x03, 0x33, 0x33}),
-			GasUsed:         4,
-			DepositNonce:    &depNonce,
+			TxHash:                txs[3].Hash(),
+			ContractAddress:       libcommon.BytesToAddress([]byte{0x03, 0x33, 0x33}),
+			GasUsed:               4,
+			BlockHash:             libcommon.BytesToHash([]byte{0x03, 0x14}),
+			BlockNumber:           big.NewInt(1),
+			TransactionIndex:      7,
+			DepositNonce:          &depNonce,
+			DepositReceiptVersion: nil,
+		},
+		&Receipt{
+			Type:              DepositTxType,
+			PostState:         libcommon.Hash{5}.Bytes(),
+			CumulativeGasUsed: 15,
+			Logs: []*Log{
+				{
+					Address: libcommon.BytesToAddress([]byte{0x33}),
+					Topics:  []libcommon.Hash{libcommon.HexToHash("dead"), libcommon.HexToHash("beef")},
+					// derived fields:
+					BlockNumber: big.NewInt(1).Uint64(),
+					TxHash:      txs[4].Hash(),
+					TxIndex:     4,
+					BlockHash:   libcommon.BytesToHash([]byte{0x03, 0x14}),
+					Index:       4,
+				},
+				{
+					Address: libcommon.BytesToAddress([]byte{0x03, 0x33}),
+					Topics:  []libcommon.Hash{libcommon.HexToHash("dead"), libcommon.HexToHash("beef")},
+					// derived fields:
+					BlockNumber: big.NewInt(1).Uint64(),
+					TxHash:      txs[4].Hash(),
+					TxIndex:     4,
+					BlockHash:   libcommon.BytesToHash([]byte{0x03, 0x14}),
+					Index:       5,
+				},
+			},
+			TxHash:                txs[4].Hash(),
+			ContractAddress:       libcommon.HexToAddress("0x3bb898b4bbe24f68a4e9be46cfe72d1787fd74f4"),
+			GasUsed:               5,
+			BlockHash:             libcommon.BytesToHash([]byte{0x03, 0x14}),
+			BlockNumber:           big.NewInt(1),
+			TransactionIndex:      4,
+			DepositNonce:          &depNonce2,
+			DepositReceiptVersion: &canyonDepositReceiptVersion,
 		},
 	}
 
@@ -310,7 +378,9 @@ func TestDeriveFields(t *testing.T) {
 		txs[0].GetNonce(),
 		txs[1].GetNonce(),
 		txs[2].GetNonce(),
-		*receipts[3].DepositNonce, // Deposit tx should use deposit nonce
+		// Deposit tx should use deposit nonce
+		*receipts[3].DepositNonce,
+		*receipts[4].DepositNonce,
 	}
 	// Clear all the computed fields and re-derive them
 	number := big.NewInt(1)
@@ -318,7 +388,7 @@ func TestDeriveFields(t *testing.T) {
 	time := uint64(0)
 
 	clearComputedFieldsOnReceipts(t, receipts)
-	if err := receipts.DeriveFields(params.TestChainConfig, hash, number.Uint64(), time, txs, []libcommon.Address{libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0})}); err != nil {
+	if err := receipts.DeriveFields(params.TestChainConfig, hash, number.Uint64(), time, txs, []libcommon.Address{libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0}), libcommon.BytesToAddress([]byte{0x0})}); err != nil {
 		t.Fatalf("DeriveFields(...) = %v, want <nil>", err)
 	}
 	// Iterate over all the computed fields and check that they're correct
@@ -478,6 +548,54 @@ func TestBedrockDepositReceiptUnchanged(t *testing.T) {
 	}
 	// And still shouldn't have a nonce
 	require.Nil(t, parsed.DepositNonce)
+	// ..or a deposit nonce
+	require.Nil(t, parsed.DepositReceiptVersion)
+}
+
+// Regolith did not include deposit nonce during receipt root construction.
+// TestReceiptEncodeIndexBugIsEnshrined makes sure this difference is preserved for backwards
+// compatibility purposes, but also that there is no discrepancy for the post-Canyon encoding.
+func TestReceiptEncodeIndexBugIsEnshrined(t *testing.T) {
+	// Check that a post-Regolith, pre-Canyon receipt produces no difference between
+	// receipts having different depositNonce
+	buf := new(bytes.Buffer)
+	receipts := Receipts{depositReceiptWithNonce}
+	receipts.EncodeIndex(0, buf)
+	indexBytesBefore := buf.Bytes()
+
+	buf2 := new(bytes.Buffer)
+	newDepositNonce := *receipts[0].DepositNonce + 1
+	receipts[0].DepositNonce = &newDepositNonce
+	receipts.EncodeIndex(0, buf2)
+	indexBytesAfter := buf2.Bytes()
+
+	require.Equal(t, indexBytesBefore, indexBytesAfter)
+
+	// Confirm the buggy encoding is as expected, which means it should encode as if it had no
+	// nonce specified (like that of a non-deposit receipt, whose encoding would differ only in the
+	// type byte).
+	buf3 := new(bytes.Buffer)
+	receipts[0].Type = eip1559Receipt.Type
+	receipts.EncodeIndex(0, buf3)
+	indexBytesNonDeposit := buf3.Bytes()
+
+	require.NotEqual(t, indexBytesBefore[0], indexBytesNonDeposit[0])
+	require.Equal(t, indexBytesBefore[1:], indexBytesNonDeposit[1:])
+
+	// Check that post-canyon changes the hash compared to pre-Canyon
+	buf4 := new(bytes.Buffer)
+	receipts = Receipts{depositReceiptWithNonceAndVersion}
+	receipts.EncodeIndex(0, buf4)
+	indexBytesCanyon := buf4.Bytes()
+	require.NotEqual(t, indexBytesBefore[1:], indexBytesCanyon[1:])
+
+	// Check that bumping the nonce post-canyon changes the hash
+	buf5 := new(bytes.Buffer)
+	bumpedNonce := *depositReceiptWithNonceAndVersion.DepositNonce + 1
+	receipts[0].DepositNonce = &bumpedNonce
+	receipts.EncodeIndex(0, buf5)
+	indexBytesCanyonBump := buf5.Bytes()
+	require.NotEqual(t, indexBytesCanyon[1:], indexBytesCanyonBump[1:])
 }
 
 func TestRoundTripReceipt(t *testing.T) {
@@ -490,6 +608,7 @@ func TestRoundTripReceipt(t *testing.T) {
 		{name: "EIP1559", rcpt: eip1559Receipt},
 		{name: "DepositNoNonce", rcpt: depositReceiptNoNonce},
 		{name: "DepositWithNonce", rcpt: depositReceiptWithNonce},
+		{name: "DepositWithNonceAndVersion", rcpt: depositReceiptWithNonceAndVersion},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -500,6 +619,8 @@ func TestRoundTripReceipt(t *testing.T) {
 			err = rlp.DecodeBytes(data, d)
 			require.NoError(t, err)
 			require.Equal(t, test.rcpt, d)
+			require.Equal(t, test.rcpt.DepositNonce, d.DepositNonce)
+			require.Equal(t, test.rcpt.DepositReceiptVersion, d.DepositReceiptVersion)
 		})
 
 		t.Run(fmt.Sprintf("%sRejectExtraData", test.name), func(t *testing.T) {
@@ -523,6 +644,7 @@ func TestRoundTripReceiptForStorage(t *testing.T) {
 		{name: "EIP1559", rcpt: eip1559Receipt},
 		{name: "DepositNoNonce", rcpt: depositReceiptNoNonce},
 		{name: "DepositWithNonce", rcpt: depositReceiptWithNonce},
+		{name: "DepositWithNonceAndVersion", rcpt: depositReceiptWithNonceAndVersion},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -537,6 +659,7 @@ func TestRoundTripReceiptForStorage(t *testing.T) {
 			require.Equal(t, test.rcpt.CumulativeGasUsed, d.CumulativeGasUsed)
 			require.Equal(t, test.rcpt.Logs, d.Logs)
 			require.Equal(t, test.rcpt.DepositNonce, d.DepositNonce)
+			require.Equal(t, test.rcpt.DepositReceiptVersion, d.DepositReceiptVersion)
 		})
 	}
 }

--- a/turbo/adapter/ethapi/api_test.go
+++ b/turbo/adapter/ethapi/api_test.go
@@ -21,7 +21,8 @@ func TestNewRPCTransactionDepositTx(t *testing.T) {
 	}
 	nonce := uint64(7)
 	depositNonce := &nonce
-	got := newRPCTransaction(tx, libcommon.Hash{}, uint64(12), uint64(1), big.NewInt(0), depositNonce)
+	receipt := &types.Receipt{DepositNonce: depositNonce}
+	got := newRPCTransaction(tx, libcommon.Hash{}, uint64(12), uint64(1), big.NewInt(0), receipt)
 	// Should provide zero values for unused fields that are required in other transactions
 	require.Equal(t, got.GasPrice, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().GasPrice = %v, want 0x0", got.GasPrice)
 	require.Equal(t, got.V, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().V = %v, want 0x0", got.V)
@@ -32,7 +33,43 @@ func TestNewRPCTransactionDepositTx(t *testing.T) {
 	require.Equal(t, *got.SourceHash, tx.SourceHash, "newRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash)
 	require.Equal(t, *got.IsSystemTx, tx.IsSystemTransaction, "newRPCTransaction().IsSystemTransaction = %v, want %v", got.IsSystemTx, tx.IsSystemTransaction)
 	require.Equal(t, got.Mint, (*hexutil.Big)(tx.Mint.ToBig()), "newRPCTransaction().Mint = %v, want %v", got.Mint, tx.Mint.ToBig())
-	require.Equal(t, got.Nonce, (hexutil.Uint64)(nonce), "newRPCTransaction().Mint = %v, want %v", got.Nonce, nonce)
+	require.Equal(t, got.Nonce, (hexutil.Uint64)(nonce), "newRPCTransaction().Nonce = %v, want %v", got.Nonce, nonce)
+}
+
+func TestNewRPCTransactionDepositTxWithVersion(t *testing.T) {
+	tx := &types.DepositTx{
+		SourceHash:          libcommon.HexToHash("0x1234"),
+		IsSystemTransaction: true,
+		Mint:                uint256.NewInt(34),
+		Value:               uint256.NewInt(1337),
+	}
+	nonce := uint64(7)
+	version := types.CanyonDepositReceiptVersion
+	receipt := &types.Receipt{
+		DepositNonce:          &nonce,
+		DepositReceiptVersion: &version,
+	}
+	got := newRPCTransaction(tx, libcommon.Hash{}, uint64(12), uint64(1), big.NewInt(0), receipt)
+	// Should provide zero values for unused fields that are required in other transactions
+	require.Equal(t, got.GasPrice, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().GasPrice = %v, want 0x0", got.GasPrice)
+	require.Equal(t, got.V, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().V = %v, want 0x0", got.V)
+	require.Equal(t, got.R, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().R = %v, want 0x0", got.R)
+	require.Equal(t, got.S, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().S = %v, want 0x0", got.S)
+
+	// Should include versioned deposit tx specific fields
+	require.Equal(t, *got.SourceHash, tx.SourceHash, "newRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash)
+	require.Equal(t, *got.IsSystemTx, tx.IsSystemTransaction, "newRPCTransaction().IsSystemTx = %v, want %v", got.IsSystemTx, tx.IsSystemTransaction)
+	require.Equal(t, got.Mint, (*hexutil.Big)(tx.Mint.ToBig()), "newRPCTransaction().Mint = %v, want %v", got.Mint, tx.Mint.ToBig())
+	require.Equal(t, got.Nonce, (hexutil.Uint64)(nonce), "newRPCTransaction().Nonce = %v, want %v", got.Nonce, nonce)
+	require.Equal(t, *got.DepositReceiptVersion, (hexutil.Uint64(version)), "newRPCTransaction().DepositReceiptVersion = %v, want %v", *got.DepositReceiptVersion, version)
+
+	// Make sure json marshal/unmarshal of the rpc tx preserves the receipt version
+	b, err := json.Marshal(got)
+	require.NoError(t, err, "marshalling failed: %w", err)
+	parsed := make(map[string]interface{})
+	err = json.Unmarshal(b, &parsed)
+	require.NoError(t, err, "unmarshalling failed: %w", err)
+	require.Equal(t, "0x1", parsed["depositReceiptVersion"])
 }
 
 func TestNewRPCTransactionOmitIsSystemTxFalse(t *testing.T) {
@@ -46,6 +83,7 @@ func TestNewRPCTransactionOmitIsSystemTxFalse(t *testing.T) {
 }
 
 func TestUnmarshalRpcDepositTx(t *testing.T) {
+	version := hexutil.Uint64(types.CanyonDepositReceiptVersion)
 	tests := []struct {
 		name     string
 		modifier func(tx *RPCTransaction)
@@ -103,6 +141,13 @@ func TestUnmarshalRpcDepositTx(t *testing.T) {
 				tx.S = (*hexutil.Big)(big.NewInt(43))
 			},
 			valid: false,
+		},
+		{
+			name: "Non-nil deposit receipt version",
+			modifier: func(tx *RPCTransaction) {
+				tx.DepositReceiptVersion = &version
+			},
+			valid: true,
 		},
 	}
 	for _, test := range tests {

--- a/turbo/adapter/ethapi/internal.go
+++ b/turbo/adapter/ethapi/internal.go
@@ -8,8 +8,8 @@ import (
 )
 
 // nolint
-func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[string]interface{}, depositNonces []*uint64) (map[string]interface{}, error) {
-	fields, err := RPCMarshalBlockDeprecated(b, inclTx, fullTx, depositNonces)
+func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[string]interface{}, receipts types.Receipts) (map[string]interface{}, error) {
+	fields, err := RPCMarshalBlockDeprecated(b, inclTx, fullTx, receipts)
 	if err != nil {
 		return nil, err
 	}
@@ -23,8 +23,8 @@ func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[st
 
 // nolint
 func RPCMarshalBlockEx(b *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash libcommon.Hash,
-	additional map[string]interface{}, depositNonces []*uint64) (map[string]interface{}, error) {
-	fields, err := RPCMarshalBlockExDeprecated(b, inclTx, fullTx, borTx, borTxHash, depositNonces)
+	additional map[string]interface{}, receipts types.Receipts) (map[string]interface{}, error) {
+	fields, err := RPCMarshalBlockExDeprecated(b, inclTx, fullTx, borTx, borTxHash, receipts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
All codes referenced from
- https://github.com/ethereum-optimism/op-geth/pull/152
- https://github.com/ethereum-optimism/op-geth/pull/167

## Description

This PR fixes two issues.

### Issue 1: Receipt Root Deposit Nonce Hashing Bug

When receipt is hashed and alters receipt root, method `EncodeIndex` is invoked.

https://github.com/testinprod-io/op-erigon/blob/91382cb9ac65d2c17b402a30176334c0f49c9ed7/core/types/receipt.go#L489

When receipt is generated from deposit tx, following case will be executed.

https://github.com/testinprod-io/op-erigon/blob/91382cb9ac65d2c17b402a30176334c0f49c9ed7/core/types/receipt.go#L508-L512

`receiptRLP` struct does not contain `DepositNonce` field, resulting in not including `DepositNonce` to receipt root. We must use `depositReceiptRLP` struct to correctly encode deposit receipts into receipt root. For backwards compatibility, we add `DepositReceiptVersion` field to receipts. 
- Canyon: `DepositReceiptVersion` is not nil. Encode using `depositReceiptRLP`
- Pre-Canyon: `DepositReceiptVersion` is nil. Encode using `receiptRLP`.

Ran
```sh
codecgen -o receipt_codecgen_gen.go -r "^Receipts$|^Receipt$|^Logs$|^Log$" -st "codec" -j=false -nx=true -ta=true -oe=false -d 2 receipt.go log.go
```
to update cbor encoding/decoding code.

### Issue 2: Receipt JSON Marshaling/Unmarshaling Bug

When receipt is JSON marshalled, it uses `receiptMarshaling` struct. Based on this, `gencodec` generates `MarshalJSON()` method. This custom method will be called when `json.Marshal` is called to receipt. 

`receiptMarshaling` struct did not contain optimism related fields. Added them for correct json marshaling for optimism.

Ran
```
gencodec -type Receipt -field-override receiptMarshaling -out gen_receipt_json.go
```
to update autogenerated codes.

## Testing

Unit tests added.

## Misc

No erigon-lib update.
