### PR TITLE
[Canyon Hard Fork] Activate Shanghai with Canyon

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1657,7 +1657,6 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	if ctx.IsSet(OverrideShanghaiTime.Name) && ctx.IsSet(OverrideOptimismCanyonFlag.Name) {
 		overrideShanghaiTime := flags.GlobalBig(ctx, OverrideShanghaiTime.Name)
 		overrideOptimismCanyonTime := flags.GlobalBig(ctx, OverrideOptimismCanyonFlag.Name)
-		fmt.Println(overrideShanghaiTime.String(), overrideOptimismCanyonTime.String())
 		if overrideShanghaiTime.Cmp(overrideOptimismCanyonTime) != 0 {
 			logger.Warn("Shanghai hardfork time is overridden by optimism canyon hardfork time",
 				"shanghai", overrideShanghaiTime.String(), "canyon", overrideOptimismCanyonTime.String())

--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -102,6 +102,14 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideShanghaiTime,
 		}
 		if config.IsOptimism() && overrideOptimismCanyonTime != nil {
 			config.CanyonTime = overrideOptimismCanyonTime
+			// Shanghai hardfork is included in canyon hardfork
+			config.ShanghaiTime = overrideOptimismCanyonTime
+		}
+		if overrideShanghaiTime != nil && config.IsOptimism() && overrideOptimismCanyonTime != nil {
+			if overrideShanghaiTime.Cmp(overrideOptimismCanyonTime) != 0 {
+				logger.Warn("Shanghai hardfork time is overridden by optimism canyon time",
+					"shanghai", overrideShanghaiTime.String(), "canyon", overrideOptimismCanyonTime.String())
+			}
 		}
 		if config.IsOptimism() && config.ChainID != nil {
 			if config.ChainID.Cmp(params.OptimismGoerliChainConfig.ChainID) == 0 {


### PR DESCRIPTION
This PR adds functionality when `--override.canyon` is set, it also initializes shanghai hard fork time because shanghai is part of canyon.

If both overrides are specified and are different, erigon will override shanghai time with canyon, and emits warning logs.