### PR TITLE
[Canyon Hard Fork] Fix EIP1559DenominatorCanyon config field name

### DIFF
--- a/consensus/misc/eip1559_test.go
+++ b/consensus/misc/eip1559_test.go
@@ -45,9 +45,9 @@ func opConfig() *chain.Config {
 	config.LondonBlock = big.NewInt(5)
 	config.CanyonTime = big.NewInt(10)
 	config.Optimism = &chain.OptimismConfig{
-		EIP1559Elasticity:            6,
-		EIP1559Denominator:           50,
-		EIP1559DenominatorPostCanyon: 250,
+		EIP1559Elasticity:        6,
+		EIP1559Denominator:       50,
+		EIP1559DenominatorCanyon: 250,
 	}
 	return config
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ledgerwatch/erigon
 go 1.19
 
 //fork with minor protobuf file changes and txpool support
-replace github.com/ledgerwatch/erigon-lib v0.0.0-20230627104814-797724496a65 => github.com/testinprod-io/erigon-lib v0.0.0-20231102054516-b93d9d11c10f
+replace github.com/ledgerwatch/erigon-lib v0.0.0-20230627104814-797724496a65 => github.com/testinprod-io/erigon-lib v0.0.0-20231107080117-508e450fb098
 
 //for local dev:
 //replace github.com/ledgerwatch/erigon-lib v0.0.0-20230423044930-fc9dd74e6407 => ../erigon-lib

--- a/go.sum
+++ b/go.sum
@@ -745,8 +745,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/supranational/blst v0.3.10 h1:CMciDZ/h4pXDDXQASe8ZGTNKUiVNxVVA5hpci2Uuhuk=
 github.com/supranational/blst v0.3.10/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/testinprod-io/erigon-lib v0.0.0-20231102054516-b93d9d11c10f h1:6/GcZLIgvF+LsbFiDabkModKXjAZml+5nddMix5XNes=
-github.com/testinprod-io/erigon-lib v0.0.0-20231102054516-b93d9d11c10f/go.mod h1:yq49cI1Z1S+aS0gj6ERZU03UIrseMmDRj4zWa1EA96Y=
+github.com/testinprod-io/erigon-lib v0.0.0-20231107080117-508e450fb098 h1:OyFkQCzCnEBcIEq8yRHMDdTwS839y/A1rLy/Y12+T8I=
+github.com/testinprod-io/erigon-lib v0.0.0-20231107080117-508e450fb098/go.mod h1:yq49cI1Z1S+aS0gj6ERZU03UIrseMmDRj4zWa1EA96Y=
 github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e h1:cR8/SYRgyQCt5cNCMniB/ZScMkhI9nk8U5C7SbISXjo=
 github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e/go.mod h1:Tu4lItkATkonrYuvtVjG0/rhy15qrNGNTjPdaphtZ/8=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=


### PR DESCRIPTION
Pin erigon-lib version to https://github.com/testinprod-io/erigon-lib/pull/27/commits/508e450fb098a4f55fc5ed760b85753cf1f69e77 which is part of https://github.com/testinprod-io/erigon-lib/pull/27.

Update test to apply field name update(`EIP1559DenominatorPostCanyon` -> `EIP1559DenominatorCanyon`) as well.