### PR TITLE
[Canyon Hard Fork] Update chainspecs

### DIFF
--- a/consensus/misc/eip1559_test.go
+++ b/consensus/misc/eip1559_test.go
@@ -45,9 +45,9 @@ func opConfig() *chain.Config {
 	config.LondonBlock = big.NewInt(5)
 	config.CanyonTime = big.NewInt(10)
 	config.Optimism = &chain.OptimismConfig{
-		EIP1559Elasticity:            6,
-		EIP1559Denominator:           50,
-		EIP1559DenominatorPostCanyon: 250,
+		EIP1559Elasticity:        6,
+		EIP1559Denominator:       50,
+		EIP1559DenominatorCanyon: 250,
 	}
 	return config
 }

--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -104,6 +104,10 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideShanghaiTime,
 			config.CanyonTime = overrideOptimismCanyonTime
 			// Shanghai hardfork is included in canyon hardfork
 			config.ShanghaiTime = overrideOptimismCanyonTime
+			if config.Optimism.EIP1559DenominatorCanyon == 0 {
+				logger.Warn("EIP1559DenominatorCanyon set to 0. Overriding to 250 to avoid divide by zero.")
+				config.Optimism.EIP1559DenominatorCanyon = 250
+			}
 		}
 		if overrideShanghaiTime != nil && config.IsOptimism() && overrideOptimismCanyonTime != nil {
 			if overrideShanghaiTime.Cmp(overrideOptimismCanyonTime) != 0 {

--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -118,6 +118,11 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideShanghaiTime,
 		if config.IsOptimism() && config.ChainID != nil {
 			if config.ChainID.Cmp(params.OptimismGoerliChainConfig.ChainID) == 0 {
 				config.RegolithTime = params.OptimismGoerliChainConfig.RegolithTime
+				if overrideOptimismCanyonTime == nil {
+					// fall back to default hardfork time
+					config.ShanghaiTime = params.OptimismGoerliChainConfig.ShanghaiTime
+					config.CanyonTime = params.OptimismGoerliChainConfig.CanyonTime
+				}
 			} else if config.ChainID.Cmp(params.OptimismMainnetChainConfig.ChainID) == 0 {
 				config.RegolithTime = params.OptimismMainnetChainConfig.RegolithTime
 			}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -296,8 +296,13 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 	backend.genesisHash = genesis.Hash()
 
 	logger.Info("Initialised chain configuration", "config", chainConfig, "genesis", genesis.Hash())
-	if chainConfig.IsOptimism() && chainConfig.RegolithTime == nil {
-		log.Warn("Optimism RegolithTime has not been set")
+	if chainConfig.IsOptimism() {
+		if chainConfig.RegolithTime == nil {
+			log.Warn("Optimism RegolithTime has not been set")
+		}
+		if chainConfig.CanyonTime == nil {
+			log.Warn("Optimism CanyonTime has not been set")
+		}
 	}
 
 	if err := backend.setUpSnapDownloader(ctx, config.Downloader); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ledgerwatch/erigon
 go 1.19
 
 //fork with minor protobuf file changes and txpool support
-replace github.com/ledgerwatch/erigon-lib v0.0.0-20230627104814-797724496a65 => github.com/testinprod-io/erigon-lib v0.0.0-20231102054516-b93d9d11c10f
+replace github.com/ledgerwatch/erigon-lib v0.0.0-20230627104814-797724496a65 => github.com/testinprod-io/erigon-lib v0.0.0-20231107080117-508e450fb098
 
 //for local dev:
 //replace github.com/ledgerwatch/erigon-lib v0.0.0-20230423044930-fc9dd74e6407 => ../erigon-lib

--- a/go.sum
+++ b/go.sum
@@ -745,8 +745,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/supranational/blst v0.3.10 h1:CMciDZ/h4pXDDXQASe8ZGTNKUiVNxVVA5hpci2Uuhuk=
 github.com/supranational/blst v0.3.10/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/testinprod-io/erigon-lib v0.0.0-20231102054516-b93d9d11c10f h1:6/GcZLIgvF+LsbFiDabkModKXjAZml+5nddMix5XNes=
-github.com/testinprod-io/erigon-lib v0.0.0-20231102054516-b93d9d11c10f/go.mod h1:yq49cI1Z1S+aS0gj6ERZU03UIrseMmDRj4zWa1EA96Y=
+github.com/testinprod-io/erigon-lib v0.0.0-20231107080117-508e450fb098 h1:OyFkQCzCnEBcIEq8yRHMDdTwS839y/A1rLy/Y12+T8I=
+github.com/testinprod-io/erigon-lib v0.0.0-20231107080117-508e450fb098/go.mod h1:yq49cI1Z1S+aS0gj6ERZU03UIrseMmDRj4zWa1EA96Y=
 github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e h1:cR8/SYRgyQCt5cNCMniB/ZScMkhI9nk8U5C7SbISXjo=
 github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e/go.mod h1:Tu4lItkATkonrYuvtVjG0/rhy15qrNGNTjPdaphtZ/8=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=

--- a/params/chainspecs/optimism-devnet.json
+++ b/params/chainspecs/optimism-devnet.json
@@ -24,6 +24,6 @@
       "eip1559DenominatorCanyon": 250
     },
     "regolithTime": 0,
-    "shanghaiTime": 0,
-    "canyonTime": 0
+    "shanghaiTime": 2,
+    "canyonTime": 2
 }

--- a/params/chainspecs/optimism-devnet.json
+++ b/params/chainspecs/optimism-devnet.json
@@ -20,7 +20,10 @@
     "terminalTotalDifficultyPassed": true,
     "optimism": {
       "eip1559Elasticity": 2,
-      "eip1559Denominator": 8
+      "eip1559Denominator": 8,
+      "eip1559DenominatorCanyon": 250
     },
-    "regolithTime": 0
+    "regolithTime": 0,
+    "shanghaiTime": 0,
+    "canyonTime": 0
 }

--- a/params/chainspecs/optimism-goerli.json
+++ b/params/chainspecs/optimism-goerli.json
@@ -20,7 +20,10 @@
     "terminalTotalDifficultyPassed": true,
     "optimism": {
         "eip1559Elasticity": 10,
-        "eip1559Denominator": 50
+        "eip1559Denominator": 50,
+        "eip1559DenominatorCanyon": 250
     },
-    "regolithTime": 1679079600
+    "regolithTime": 1679079600,
+    "shanghaiTime": 1698436800,
+    "canyonTime": 1698436800
 }

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -98,3 +98,30 @@ func TestCheckCompatible(t *testing.T) {
 		}
 	}
 }
+
+// TODO: remove when superchain-registry is integrated
+// TestCanyonTimestampOnBlockBoundary asserts that Canyon will activate on a block's timestamp.
+// This is critical because the create2Deployer only activates on a block's timestamp.
+func TestCanyonTimestampOnBlockBoundary(t *testing.T) {
+	superchainConfigs := []*chain.Config{OptimismMainnetChainConfig, OptimismGoerliChainConfig, OptimismDevnetChainConfig}
+	l2BlockTime := 2
+	for _, config := range superchainConfigs {
+		if config.CanyonTime == nil {
+			continue
+		}
+		regolithTime := 0
+		if config.RegolithTime != nil {
+			regolithTime = int(config.RegolithTime.Int64())
+		}
+		canyonTime := int(config.CanyonTime.Int64())
+		if regolithTime > canyonTime {
+			t.Fatalf("Canyon time on superchain %v is less then Regolith time. canyon time: %v, regolith time: %v",
+				config.ChainName, canyonTime, regolithTime)
+		}
+		canyonOffset := canyonTime - regolithTime
+		if canyonOffset%l2BlockTime != 0 {
+			t.Fatalf("Canyon time on superchain %v is not on the block time. canyon time: %v, regolith time: %v, block time: %v",
+				config.ChainName, canyonTime, regolithTime, l2BlockTime)
+		}
+	}
+}


### PR DESCRIPTION
Refer to
- https://github.com/ethereum-optimism/op-geth/pull/175
- https://github.com/ethereum-optimism/superchain-registry/pull/28

## Description

Initialize canyon time for op-goerli and devnet.
- op-goerli: `1698436800`
- op-devnet: `0`

Initialize `EIP1559DenominatorCanyon` to not to be zero when canyon is activated, to avoid divide by zero error.
Fall back for default canyon time for op-goerli when time is not properly set.

## Testing

Add unit test to check canyon time to ensure create2deployer is deployed.

