### PR TITLE
Fix snapshot related params & flag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -673,6 +673,7 @@ var (
 	}
 	SnapStopFlag = cli.BoolFlag{
 		Name:  ethconfig.FlagSnapStop,
+		Value: true,
 		Usage: "Workaround to stop producing new snapshots, if you meet some snapshots-related critical bug. It will stop move historical data from DB to new immutable snapshots. DB will grow and may slightly slow-down - and removing this flag in future will not fix this effect (db size will not greatly reduce).",
 	}
 	TorrentVerbosityFlag = cli.IntFlag{

--- a/params/network_params.go
+++ b/params/network_params.go
@@ -57,5 +57,5 @@ const (
 	// considered immutable (i.e. soft finality). It is used by the downloader as a
 	// hard limit against deep ancestors, by the blockchain against deep reorgs, by
 	// the freezer as the cutoff threshold and by clique as the snapshot trust limit.
-	FullImmutabilityThreshold = 90000
+	FullImmutabilityThreshold = 90000 * 6 // Set higher threshold for OP chains
 )


### PR DESCRIPTION
It has yet to be confirmed that the Erigon snapshot works with OP chains.
So it's highly recommended to disable snapshot building.
This PR contains enabling SnapStopFlag as the default and increasing FullImmutabilityThreshold to prevent snapshot-related derivation errors.

- Increase FullImmutabilityThreshold
- Disable snapshot producing as default