### PR TITLE
Fix forkchoiceupdated hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,10 +256,11 @@ release: git-submodules
 		--skip-validate
 
 	@docker image push --all-tags testinprod/op-erigon
+
 	@docker manifest create testinprod/op-erigon:latest \
-		--amend testinprod/op-erigon:$$(echo ${VERSION} | cut -c 2- )-amd64 \
-		--amend testinprod/op-erigon:$$(echo ${VERSION} | cut -c 2- )-arm64
-	@docker manifest push testinprod/op-erigon:latest
+    	--amend testinprod/op-erigon:$$(echo ${VERSION} | cut -c 2- )-amd64 \
+    	--amend testinprod/op-erigon:$$(echo ${VERSION} | cut -c 2- )-arm64
+	@if echo "$(VERSION)" | grep -iq "rc"; then docker manifest push testinprod/op-erigon:latest; fi
 
 # since DOCKER_UID, DOCKER_GID are default initialized to the current user uid/gid,
 # we need separate envvars to facilitate creation of the erigon user on the host OS.

--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -80,7 +80,8 @@ func (e *EthereumExecutionModule) UpdateForkChoice(ctx context.Context, req *exe
 	select {
 	case <-fcuTimer.C:
 		e.logger.Debug("treating forkChoiceUpdated as asynchronous as it is taking too long")
-		// op-node does not handle SYNCING as asynchronous forkChoiceUpdated. must return error.
+		// op-node does not handle SYNCING as asynchronous forkChoiceUpdated.
+		// return an error and make op-node retry
 		return nil, errors.New("forkChoiceUpdated timeout")
 		//return &execution.ForkChoiceReceipt{
 		//	LatestValidHash: gointerfaces.ConvertHashToH256(libcommon.Hash{}),
@@ -105,7 +106,8 @@ func writeForkChoiceHashes(tx kv.RwTx, blockHash, safeHash, finalizedHash libcom
 
 func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, blockHash, safeHash, finalizedHash libcommon.Hash, outcomeCh chan forkchoiceOutcome) {
 	if !e.semaphore.TryAcquire(1) {
-		// op-node does not handle SYNCING as asynchronous forkChoiceUpdated. must return error.
+		// op-node does not handle SYNCING as asynchronous forkChoiceUpdated.
+		// return an error and make op-node retry
 		sendForkchoiceErrorWithoutWaiting(outcomeCh, errors.New("cannot update forkchoice. execution service is busy"))
 		//sendForkchoiceReceiptWithoutWaiting(outcomeCh, &execution.ForkChoiceReceipt{
 		//	LatestValidHash: gointerfaces.ConvertHashToH256(libcommon.Hash{}),


### PR DESCRIPTION
- Re-enable timeout for forkChoiceUpdated API, but return an error instead of SYNCING.
- op-node does not handle SYNCING as asynchronous forkChoiceUpdated. So error will make op-node retry engine API.
- Do not update `latest` tag if the version is RC.