### PR TITLE
[Ecotone] L2 Cancun Support

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1729,7 +1729,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 
 	if ctx.IsSet(OverrideCancunFlag.Name) {
 		cfg.OverrideCancunTime = flags.GlobalBig(ctx, OverrideCancunFlag.Name)
-
+		cfg.TxPool.OverrideCancunTime = cfg.OverrideCancunTime
 	}
 	if ctx.IsSet(OverrideShanghaiTime.Name) {
 		cfg.OverrideShanghaiTime = flags.GlobalBig(ctx, OverrideShanghaiTime.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1729,7 +1729,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 
 	if ctx.IsSet(OverrideCancunFlag.Name) {
 		cfg.OverrideCancunTime = flags.GlobalBig(ctx, OverrideCancunFlag.Name)
-		cfg.TxPool.OverrideCancunTime = cfg.OverrideCancunTime
+
 	}
 	if ctx.IsSet(OverrideShanghaiTime.Name) {
 		cfg.OverrideShanghaiTime = flags.GlobalBig(ctx, OverrideShanghaiTime.Name)
@@ -1754,6 +1754,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		cfg.OverrideOptimismEcotoneTime = flags.GlobalBig(ctx, OverrideOptimismEcotoneFlag.Name)
 		// Cancun hardfork is included in Ecotone hardfork
 		cfg.OverrideCancunTime = flags.GlobalBig(ctx, OverrideOptimismEcotoneFlag.Name)
+		cfg.TxPool.OverrideCancunTime = flags.GlobalBig(ctx, OverrideOptimismEcotoneFlag.Name)
 	}
 	if ctx.IsSet(OverrideCancunFlag.Name) && ctx.IsSet(OverrideOptimismEcotoneFlag.Name) {
 		overrideCancunTime := flags.GlobalBig(ctx, OverrideCancunFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -125,6 +125,10 @@ var (
 		Name:  "override.canyon",
 		Usage: "Manually specify the Optimism Canyon fork time, overriding the bundled setting",
 	}
+	OverrideOptimismEcotoneFlag = flags.BigFlag{
+		Name:  "override.ecotone",
+		Usage: "Manually specify the Optimism Ecotone fork time, overriding the bundled setting",
+	}
 	// Ethash settings
 	EthashCachesInMemoryFlag = cli.IntFlag{
 		Name:  "ethash.cachesinmem",
@@ -1744,6 +1748,19 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		if overrideShanghaiTime.Cmp(overrideOptimismCanyonTime) != 0 {
 			logger.Warn("Shanghai hardfork time is overridden by optimism canyon hardfork time",
 				"shanghai", overrideShanghaiTime.String(), "canyon", overrideOptimismCanyonTime.String())
+		}
+	}
+	if ctx.IsSet(OverrideOptimismEcotoneFlag.Name) {
+		cfg.OverrideOptimismEcotoneTime = flags.GlobalBig(ctx, OverrideOptimismEcotoneFlag.Name)
+		// Cancun hardfork is included in Ecotone hardfork
+		cfg.OverrideCancunTime = flags.GlobalBig(ctx, OverrideOptimismEcotoneFlag.Name)
+	}
+	if ctx.IsSet(OverrideCancunFlag.Name) && ctx.IsSet(OverrideOptimismEcotoneFlag.Name) {
+		overrideCancunTime := flags.GlobalBig(ctx, OverrideCancunFlag.Name)
+		overrideOptimismEcotoneTime := flags.GlobalBig(ctx, OverrideOptimismEcotoneFlag.Name)
+		if overrideCancunTime.Cmp(overrideOptimismEcotoneTime) != 0 {
+			logger.Warn("Cancun hardfork time is overridden by optimism Ecotone hardfork time",
+				"cancun", overrideCancunTime.String(), "ecotone", overrideOptimismEcotoneTime.String())
 		}
 	}
 	if ctx.IsSet(InternalConsensusFlag.Name) && clparams.EmbeddedSupported(cfg.NetworkID) {

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -33,7 +33,7 @@ func TestGenesisBlockHashes(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer tx.Rollback()
-		_, block, err := core.WriteGenesisBlock(tx, genesis, nil, nil, nil, "", logger)
+		_, block, err := core.WriteGenesisBlock(tx, genesis, nil, nil, nil, nil, "", logger)
 		require.NoError(t, err)
 		expect := params.GenesisHashByChainName(network)
 		require.NotNil(t, expect, network)
@@ -80,13 +80,13 @@ func TestCommitGenesisIdempotency(t *testing.T) {
 	defer tx.Rollback()
 
 	genesis := core.GenesisBlockByChainName(networkname.MainnetChainName)
-	_, _, err = core.WriteGenesisBlock(tx, genesis, nil, nil, nil, "", logger)
+	_, _, err = core.WriteGenesisBlock(tx, genesis, nil, nil, nil, nil, "", logger)
 	require.NoError(t, err)
 	seq, err := tx.ReadSequence(kv.EthTx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), seq)
 
-	_, _, err = core.WriteGenesisBlock(tx, genesis, nil, nil, nil, "", logger)
+	_, _, err = core.WriteGenesisBlock(tx, genesis, nil, nil, nil, nil, "", logger)
 	require.NoError(t, err)
 	seq, err = tx.ReadSequence(kv.EthTx)
 	require.NoError(t, err)

--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -67,16 +67,16 @@ import (
 //
 // The returned chain configuration is never nil.
 func CommitGenesisBlock(db kv.RwDB, genesis *types.Genesis, tmpDir string, logger log.Logger) (*chain.Config, *types.Block, error) {
-	return CommitGenesisBlockWithOverride(db, genesis, nil, nil, nil, tmpDir, logger)
+	return CommitGenesisBlockWithOverride(db, genesis, nil, nil, nil, nil, tmpDir, logger)
 }
 
-func CommitGenesisBlockWithOverride(db kv.RwDB, genesis *types.Genesis, overrideCancunTime, overrideShanghaiTime, overrideOptimismCanyonTime *big.Int, tmpDir string, logger log.Logger) (*chain.Config, *types.Block, error) {
+func CommitGenesisBlockWithOverride(db kv.RwDB, genesis *types.Genesis, overrideCancunTime, overrideShanghaiTime, overrideOptimismCanyonTime, overrideOptimismEcotoneTime *big.Int, tmpDir string, logger log.Logger) (*chain.Config, *types.Block, error) {
 	tx, err := db.BeginRw(context.Background())
 	if err != nil {
 		return nil, nil, err
 	}
 	defer tx.Rollback()
-	c, b, err := WriteGenesisBlock(tx, genesis, overrideCancunTime, overrideShanghaiTime, overrideOptimismCanyonTime, tmpDir, logger)
+	c, b, err := WriteGenesisBlock(tx, genesis, overrideCancunTime, overrideShanghaiTime, overrideOptimismCanyonTime, overrideOptimismEcotoneTime, tmpDir, logger)
 	if err != nil {
 		return c, b, err
 	}
@@ -87,7 +87,8 @@ func CommitGenesisBlockWithOverride(db kv.RwDB, genesis *types.Genesis, override
 	return c, b, nil
 }
 
-func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideCancunTime, overrideShanghaiTime, overrideOptimismCanyonTime *big.Int, tmpDir string, logger log.Logger) (*chain.Config, *types.Block, error) {
+func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideCancunTime, overrideShanghaiTime, overrideOptimismCanyonTime, overrideOptimismEcotoneTime *big.Int,
+	tmpDir string, logger log.Logger) (*chain.Config, *types.Block, error) {
 	var storedBlock *types.Block
 	if genesis != nil && genesis.Config == nil {
 		return params.AllProtocolChanges, nil, types.ErrGenesisNoConfig
@@ -99,6 +100,9 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideCancunTime, o
 	}
 
 	applyOverrides := func(config *chain.Config) {
+		if overrideShanghaiTime != nil {
+			config.ShanghaiTime = overrideShanghaiTime
+		}
 		if overrideCancunTime != nil {
 			config.CancunTime = overrideCancunTime
 		}
@@ -115,6 +119,17 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideCancunTime, o
 			if overrideShanghaiTime.Cmp(overrideOptimismCanyonTime) != 0 {
 				logger.Warn("Shanghai hardfork time is overridden by optimism canyon time",
 					"shanghai", overrideShanghaiTime.String(), "canyon", overrideOptimismCanyonTime.String())
+			}
+		}
+		if config.IsOptimism() && overrideOptimismEcotoneTime != nil {
+			config.EcotoneTime = overrideOptimismEcotoneTime
+			// Cancun hardfork is included in Ecotone hardfork
+			config.CancunTime = overrideOptimismEcotoneTime
+		}
+		if overrideCancunTime != nil && config.IsOptimism() && overrideOptimismEcotoneTime != nil {
+			if overrideCancunTime.Cmp(overrideOptimismEcotoneTime) != 0 {
+				logger.Warn("Cancun hardfork time is overridden by optimism Ecotone time",
+					"cancun", overrideCancunTime.String(), "ecotone", overrideOptimismEcotoneTime.String())
 			}
 		}
 	}

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -45,7 +45,7 @@ func MakeSigner(config *chain.Config, blockNumber uint64, blockTime uint64) *Sig
 	}
 	signer.unprotected = true
 	switch {
-	case config.IsCancun(blockTime):
+	case config.IsCancun(blockTime) && !config.IsOptimism():
 		// All transaction types are still supported
 		signer.protected = true
 		signer.accessList = true
@@ -100,7 +100,7 @@ func LatestSigner(config *chain.Config) *Signer {
 	signer.chainID.Set(chainId)
 	signer.chainIDMul.Mul(chainId, u256.Num2)
 	if config.ChainID != nil {
-		if config.CancunTime != nil {
+		if config.CancunTime != nil && !config.IsOptimism() {
 			signer.blob = true
 		}
 		if config.LondonBlock != nil {

--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -70,6 +70,8 @@ type Config struct {
 	BedrockBlock *big.Int `json:"bedrockBlock,omitempty"` // Bedrock switch block (nil = no fork, 0 = already on optimism bedrock)
 	RegolithTime *big.Int `json:"regolithTime,omitempty"` // Regolith switch time (nil = no fork, 0 = already on optimism regolith)
 	CanyonTime   *big.Int `json:"canyonTime,omitempty"`   // Canyon switch time (nil = no fork, 0 = already on optimism canyon)
+	// Delta: the Delta upgrade does not affect the execution-layer, and is thus not configurable in the chain config.
+	EcotoneTime *big.Int `json:"ecotoneTime,omitempty"` // Ecotone switch time (nil = no fork, 0 = already on optimism ecotone)
 
 	Eip1559FeeCollector           *common.Address `json:"eip1559FeeCollector,omitempty"`           // (Optional) Address where burnt EIP-1559 fees go to
 	Eip1559FeeCollectorTransition *big.Int        `json:"eip1559FeeCollectorTransition,omitempty"` // (Optional) Block from which burnt EIP-1559 fees go to the Eip1559FeeCollector
@@ -237,6 +239,10 @@ func (c *Config) IsCanyon(time uint64) bool {
 	return isForked(c.CanyonTime, time)
 }
 
+func (c *Config) IsEcotone(time uint64) bool {
+	return isForked(c.EcotoneTime, time)
+}
+
 // IsOptimism returns whether the node is an optimism node or not.
 func (c *Config) IsOptimism() bool {
 	return c.Optimism != nil
@@ -253,6 +259,10 @@ func (c *Config) IsOptimismRegolith(time uint64) bool {
 
 func (c *Config) IsOptimismCanyon(time uint64) bool {
 	return c.IsOptimism() && c.IsCanyon(time)
+}
+
+func (c *Config) IsOptimismEcotone(time uint64) bool {
+	return c.IsOptimism() && c.IsEcotone(time)
 }
 
 // IsOptimismPreBedrock returns true iff this is an optimism node & bedrock is not yet active

--- a/erigon-lib/txpool/pool.go
+++ b/erigon-lib/txpool/pool.go
@@ -825,6 +825,9 @@ func (p *TxPool) validateTx(txn *types.TxSlot, isLocal bool, stateCache kvcache.
 	if txn.Type == types.DepositTxType {
 		return txpoolcfg.TxTypeNotSupported
 	}
+	if p.cfg.Optimism && txn.Type == types.BlobTxType {
+		return txpoolcfg.TxTypeNotSupported
+	}
 
 	isShanghai := p.isShanghai()
 	if isShanghai {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -300,7 +300,7 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 			genesisSpec = nil
 		}
 		var genesisErr error
-		chainConfig, genesis, genesisErr = core.WriteGenesisBlock(tx, genesisSpec, config.OverrideCancunTime, config.OverrideShanghaiTime, config.OverrideOptimismCanyonTime, tmpdir, logger)
+		chainConfig, genesis, genesisErr = core.WriteGenesisBlock(tx, genesisSpec, config.OverrideCancunTime, config.OverrideShanghaiTime, config.OverrideOptimismCanyonTime, config.OverrideOptimismEcotoneTime, tmpdir, logger)
 		if _, ok := genesisErr.(*chain.ConfigCompatError); genesisErr != nil && !ok {
 			return genesisErr
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -328,6 +328,9 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 		if chainConfig.CanyonTime == nil {
 			log.Warn("Optimism CanyonTime has not been set")
 		}
+		if chainConfig.EcotoneTime == nil {
+			log.Warn("Optimism EcotoneTime has not been set")
+		}
 	}
 
 	if err := backend.setUpSnapDownloader(ctx, config.Downloader); err != nil {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -248,9 +248,11 @@ type Config struct {
 	SentinelAddr                string
 	SentinelPort                uint64
 
-	OverrideCancunTime         *big.Int `toml:",omitempty"`
-	OverrideShanghaiTime       *big.Int `toml:",omitempty"`
-	OverrideOptimismCanyonTime *big.Int `toml:",omitempty"`
+	OverrideCancunTime   *big.Int `toml:",omitempty"`
+	OverrideShanghaiTime *big.Int `toml:",omitempty"`
+
+	OverrideOptimismCanyonTime  *big.Int `toml:",omitempty"`
+	OverrideOptimismEcotoneTime *big.Int `toml:",omitempty"`
 
 	DropUselessPeers bool
 

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/emicklei/dot v1.6.0
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240103191009-655947053753
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240110203637-8dbdcf965b5f
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35
 	github.com/go-chi/chi/v5 v5.0.10

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erigontech/mdbx-go v0.27.17 h1:+LOuGmdrD74psBVHDaS3cFXzI9tTSfLcUvOUtMwX2Ok=
 github.com/erigontech/mdbx-go v0.27.17/go.mod h1:FAMxbOgqOnRDx51j8HjuJZIgznbDwjX7LItd+/UWyA4=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240103191009-655947053753 h1:DL667cfM6peU8H9Ut/uu9h9Bd4gQCcJrjq+yYsfYwjk=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240103191009-655947053753/go.mod h1:/70H/KqrtKcvWvNGVj6S3rAcLC+kUPr3t2aDmYIS+Xk=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240110203637-8dbdcf965b5f h1:2Pfc9KpH/FvuBGVnwKDt+G77Ap/WEw7P+hzhBuGb2ks=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240110203637-8dbdcf965b5f/go.mod h1:/70H/KqrtKcvWvNGVj6S3rAcLC+kUPr3t2aDmYIS+Xk=
 github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c h1:CndMRAH4JIwxbW8KYq6Q+cGWcGHz0FjGR3QqcInWcW0=
 github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c/go.mod h1:AzA8Lj6YtixmJWL+wkKoBGsLWy9gFrAzi4g+5bCKwpY=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/params/chainspecs/op-devnet.json
+++ b/params/chainspecs/op-devnet.json
@@ -25,5 +25,7 @@
     },
     "regolithTime": 0,
     "shanghaiTime": 2,
-    "canyonTime": 2
+    "canyonTime": 2,
+    "cancunTime": 2,
+    "ecotoneTime": 2
 }

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -107,8 +107,8 @@ func LoadSuperChainConfig(opStackChainCfg *superchain.ChainConfig) *chain.Config
 		ArrowGlacierBlock:             common.Big0,
 		GrayGlacierBlock:              common.Big0,
 		MergeNetsplitBlock:            common.Big0,
-		ShanghaiTime:                  new(big.Int).SetUint64(*superchainConfig.Config.CanyonTime),  // Shanghai activates with Canyon
-		CancunTime:                    new(big.Int).SetUint64(*superchainConfig.Config.EcotoneTime), // CancunTime activates with Ecotone
+		ShanghaiTime:                  nil,
+		CancunTime:                    nil,
 		PragueTime:                    nil,
 		BedrockBlock:                  common.Big0,
 		RegolithTime:                  big.NewInt(0),
@@ -122,6 +122,13 @@ func LoadSuperChainConfig(opStackChainCfg *superchain.ChainConfig) *chain.Config
 			EIP1559Denominator:       50,
 			EIP1559DenominatorCanyon: 250,
 		},
+	}
+
+	if superchainConfig.Config.CanyonTime != nil {
+		out.ShanghaiTime = new(big.Int).SetUint64(*superchainConfig.Config.CanyonTime) // Shanghai activates with Canyon
+	}
+	if superchainConfig.Config.EcotoneTime != nil {
+		out.CancunTime = new(big.Int).SetUint64(*superchainConfig.Config.EcotoneTime) // CancunTime activates with Ecotone
 	}
 
 	// note: no actual parameters are being loaded, yet.

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -107,8 +107,8 @@ func LoadSuperChainConfig(opStackChainCfg *superchain.ChainConfig) *chain.Config
 		ArrowGlacierBlock:             common.Big0,
 		GrayGlacierBlock:              common.Big0,
 		MergeNetsplitBlock:            common.Big0,
-		ShanghaiTime:                  new(big.Int).SetUint64(*superchainConfig.Config.CanyonTime), // Shanghai activates with Canyon
-		CancunTime:                    nil,
+		ShanghaiTime:                  new(big.Int).SetUint64(*superchainConfig.Config.CanyonTime),  // Shanghai activates with Canyon
+		CancunTime:                    new(big.Int).SetUint64(*superchainConfig.Config.EcotoneTime), // CancunTime activates with Ecotone
 		PragueTime:                    nil,
 		BedrockBlock:                  common.Big0,
 		RegolithTime:                  big.NewInt(0),

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -154,6 +154,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.OverrideCancunFlag,
 	&utils.OverrideShanghaiTime,
 	&utils.OverrideOptimismCanyonFlag,
+	&utils.OverrideOptimismEcotoneFlag,
 	&utils.RollupSequencerHTTPFlag,
 	&utils.RollupHistoricalRPCFlag,
 	&utils.RollupHistoricalRPCTimeoutFlag,


### PR DESCRIPTION
This PR mirrors https://github.com/ethereum-optimism/op-geth/pull/205

Changes:
- Add Ecotone activation time
- explicitly disable Blob transactions
- explicitly change signer methods to use London signer instead of Cancun signer
- activate Cancun when Ecotone superchain fork is set
- update superchain-registry dep
- Add override Ecotone flag