### PR TITLE
Allow forkchoiceUpdatedV3 before Cancun

### DIFF
--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -461,12 +461,14 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 
 	if payloadAttributes != nil {
 		timestamp := uint64(payloadAttributes.Timestamp)
-		if !s.config.IsCancun(timestamp) && version >= clparams.DenebVersion { // V3 before cancun
-			if payloadAttributes.ParentBeaconBlockRoot == nil {
-				return nil, &rpc.InvalidParamsError{Message: "Beacon Root missing"}
-			}
-			return nil, &rpc.UnsupportedForkError{Message: "Unsupported fork"}
-		}
+		// op-node sends V3 before Cancun, without beacon root.
+		// so we must allow V3 before cancun to support forkChoiceUpdated backward compatibility
+		//if !s.config.IsCancun(timestamp) && version >= clparams.DenebVersion { // V3 before cancun
+		//	if payloadAttributes.ParentBeaconBlockRoot == nil {
+		//		return nil, &rpc.InvalidParamsError{Message: "Beacon Root missing"}
+		//	}
+		//	return nil, &rpc.UnsupportedForkError{Message: "Unsupported fork"}
+		//}
 		if s.config.IsCancun(timestamp) && version < clparams.DenebVersion { // Not V3 after cancun
 			if payloadAttributes.ParentBeaconBlockRoot != nil {
 				return nil, &rpc.InvalidParamsError{Message: "Unexpected Beacon Root"}
@@ -528,7 +530,7 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 		req.Withdrawals = engine_types.ConvertWithdrawalsToRpc(payloadAttributes.Withdrawals)
 	}
 
-	if version >= clparams.DenebVersion {
+	if payloadAttributes.ParentBeaconBlockRoot != nil && version >= clparams.DenebVersion {
 		req.ParentBeaconBlockRoot = gointerfaces.ConvertHashToH256(*payloadAttributes.ParentBeaconBlockRoot)
 	}
 

--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -414,8 +414,7 @@ func (s *EngineServer) getPayload(ctx context.Context, payloadId uint64, version
 	data := resp.Data
 
 	ts := data.ExecutionPayload.Timestamp
-	if (!s.config.IsCancun(ts) && version >= clparams.DenebVersion) ||
-		(s.config.IsCancun(ts) && version < clparams.DenebVersion) {
+	if s.config.IsCancun(ts) && version < clparams.DenebVersion {
 		return nil, &rpc.UnsupportedForkError{Message: "Unsupported fork"}
 	}
 


### PR DESCRIPTION
The latest version of op-node sends V3 before Cancun without beacon root. ([impl](https://github.com/ethereum-optimism/optimism/blob/develop/op-service/sources/engine_client.go#L61))
so we must allow V3 before cancun to support forkChoiceUpdated backward compatibility.