### PR TITLE
fix: computeRollupGas high CPU usage under load

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -104,7 +104,7 @@ type TransactionMisc struct {
 	from atomic.Value
 
 	// cache how much gas the tx takes on L1 for its share of rollup data
-	rollupGas atomic.Value
+	rollupGas atomic.Pointer[types2.RollupCostData]
 }
 
 type rollupGasCounter struct {
@@ -134,7 +134,7 @@ func (tm *TransactionMisc) computeRollupGas(tx interface {
 		return types2.RollupCostData{}
 	}
 	if v := tm.rollupGas.Load(); v != nil {
-		return v.(types2.RollupCostData)
+		return *v
 	}
 	var c rollupGasCounter
 	var buf bytes.Buffer
@@ -147,7 +147,7 @@ func (tm *TransactionMisc) computeRollupGas(tx interface {
 		log.Error("failed to compute rollup cost data", "err", err)
 	}
 	total := types2.RollupCostData{Zeroes: c.zeroes, Ones: c.ones, FastLzSize: c.fastLzSize}
-	tm.rollupGas.Store(total)
+	tm.rollupGas.Store(&total)
 	return total
 }
 


### PR DESCRIPTION
After a bit of investigation regarding #117 , I finally pinpointed it to the usage of atomic.Value. 
It seems like the Store method does quite a few things and could cause a lot of busy looping in case of high contention.
A replaced the cache values on TransactionMisc by atomic.Pointer, and it seems to fix the perf issue.
No more atomic.* in the profiles during high query load.