### PR TITLE
Fix test-erigon-ext

### DIFF
--- a/tests/erigon-ext-test/go.mod.template
+++ b/tests/erigon-ext-test/go.mod.template
@@ -2,8 +2,8 @@ module example.com/erigon-ext-test
 
 go 1.20
 
-require github.com/ledgerwatch/erigon $COMMIT_SHA
-
-replace github.com/ledgerwatch/erigon-lib => github.com/ledgerwatch/erigon/erigon-lib $COMMIT_SHA
+// TODO: Change module path to testinprod-io/op-erigon
+replace github.com/ledgerwatch/erigon => github.com/testinprod-io/op-erigon $COMMIT_SHA
+replace github.com/ledgerwatch/erigon-lib => github.com/testinprod-io/op-erigon/erigon-lib $COMMIT_SHA
 
 require github.com/ethereum/go-ethereum v1.13.3


### PR DESCRIPTION
In `v2.55.1-0.4.0`, integration test workflow has failed due to the module path mismatch. I have fixed by replacing module with `testinprod-io/op-erigon` for now, but we should replace the main module to testinprod-io/op-erigon in the future. https://github.com/testinprod-io/op-erigon/issues/136