### PR TITLE
Update latest chain config from superchain registry

### DIFF
--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -202,6 +202,7 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideCancunTime, o
 		if !reflect.DeepEqual(newCfg, storedCfg) {
 			log.Info("Update latest chain config from superchain registry")
 		}
+		// rewrite using superchain config just in case
 		if err := rawdb.WriteChainConfig(tx, storedHash, newCfg); err != nil {
 			return newCfg, nil, err
 		}

--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -197,15 +197,8 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideCancunTime, o
 		applyOverrides(newCfg)
 	}
 
-	// Special case: temporal fix for optimism mainnet database which contains incorrect chainspec.
-	// If london block number is set to previous wrong chainspec, overwrite with correct chainspec.
-	// Following code will be removed after we are confident that previous dbs are all corrected.
-	// https://github.com/testinprod-io/op-erigon/issues/71
-	if storedCfg.ChainName == networkname.OPMainnetChainName &&
-		newCfg.ChainName == networkname.OPMainnetChainName &&
-		storedCfg.LondonBlock.Uint64() == 3950000 &&
-		newCfg.LondonBlock.Uint64() == 105235063 {
-		log.Warn("Override chainconfig for Optimism Mainnet chainspec correction")
+	if newCfg.IsOptimism() {
+		log.Info("Update latest chain config from superchain registry")
 		if err := rawdb.WriteChainConfig(tx, storedHash, newCfg); err != nil {
 			return newCfg, nil, err
 		}

--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"reflect"
 	"sync"
 
 	"github.com/c2h5oh/datasize"
@@ -198,7 +199,9 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideCancunTime, o
 	}
 
 	if newCfg.IsOptimism() {
-		log.Info("Update latest chain config from superchain registry")
+		if !reflect.DeepEqual(newCfg, storedCfg) {
+			log.Info("Update latest chain config from superchain registry")
+		}
 		if err := rawdb.WriteChainConfig(tx, storedHash, newCfg); err != nil {
 			return newCfg, nil, err
 		}


### PR DESCRIPTION
A user [reported](https://discord.com/channels/1095246127965671424/1095246128766787641/1206627284451332146) that the superchain config(Shanghai Time) of op-mainnet is not applied when executing doCallMany.

The root cause is that we set the wrong value for op-mainnet `BerlinBlock` in the [past PR](https://github.com/testinprod-io/op-erigon/pull/72/files). The correct value is 3950000. ([ref](https://github.com/ethereum-optimism/op-geth/blob/optimism/params/superchain.go#L101)) Because of this mismatch, `genesis_write()` returns [`CompatibilityError`](https://github.com/testinprod-io/op-erigon/blob/op-erigon/core/genesis_write.go#L221) and it does not write the new config into its DB.

Therefore in some APIs, op-erigon tried to read chain config from DB directly but it was outdated. Block production was not affected because it's used the config returned from `genesis_write()`.

So I decided to write chain config into DB every time op-erigon launches, for OP chains.