### PR TITLE
Update superchain-registry version for Mainnet Ecotone upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/emicklei/dot v1.6.0
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240220093926-a87e7b7a2f77
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240229171554-54fc16ca2a16
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35
 	github.com/go-chi/chi/v5 v5.0.10

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erigontech/mdbx-go v0.27.21 h1:Pv47QIiRXR8Nv+nltZteLm4xkRwuvqmOCjzZj9X0s1A=
 github.com/erigontech/mdbx-go v0.27.21/go.mod h1:FAMxbOgqOnRDx51j8HjuJZIgznbDwjX7LItd+/UWyA4=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240220093926-a87e7b7a2f77 h1:1mg5LRfNLeeZ5WopoZM27qcjIJ8mBqUwV2B4LaGiG40=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240220093926-a87e7b7a2f77/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240229171554-54fc16ca2a16 h1:r3d42CFNNHzjbHb6efRbTRLXwtdCaO+nF8GQaJ6h+jo=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240229171554-54fc16ca2a16/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c h1:CndMRAH4JIwxbW8KYq6Q+cGWcGHz0FjGR3QqcInWcW0=
 github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c/go.mod h1:AzA8Lj6YtixmJWL+wkKoBGsLWy9gFrAzi4g+5bCKwpY=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=


### PR DESCRIPTION
Mainnet Ecotone upgrade time has been changed.
1710781201 # Mon Mar 18 17:00:01 UTC 2024 -> 1710374401 # Thu Mar 14 00:00:01 UTC 2024