### PR TITLE
Fix deposit receipt nonce

### DIFF
--- a/turbo/jsonrpc/eth_block.go
+++ b/turbo/jsonrpc/eth_block.go
@@ -3,11 +3,12 @@ package jsonrpc
 import (
 	"context"
 	"fmt"
+	"math/big"
+	"time"
+
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon-lib/opstack"
 	"github.com/ledgerwatch/erigon/cl/clparams"
-	"math/big"
-	"time"
 
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
@@ -203,6 +204,15 @@ func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber
 		return nil, err
 	}
 	defer tx.Rollback()
+
+	chainConfig, err := api.chainConfig(tx)
+	if err != nil {
+		return nil, err
+	}
+	if chainConfig.IsOptimism() && number == rpc.PendingBlockNumber {
+		number = rpc.LatestBlockNumber
+	}
+
 	b, err := api.blockByNumber(ctx, number, tx)
 	if err != nil {
 		return nil, err
@@ -219,10 +229,6 @@ func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber
 		additionalFields["totalDifficulty"] = (*hexutil.Big)(td)
 	}
 
-	chainConfig, err := api.chainConfig(tx)
-	if err != nil {
-		return nil, err
-	}
 	var borTx types.Transaction
 	var borTxHash common.Hash
 	if chainConfig.Bor != nil {


### PR DESCRIPTION
The receipts stored in the DB do not contain the nonce for the deposit transactions.  This change triggers the receipt retrieval to go through the more full path which includes the deposit nonce.

Additionally, it fixes the pending RPC block number to correspond to the latest block number as is the behavior in op-geth.