### PR TITLE
Add json key for NoRefunds and StateOverrides trace options

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -15,8 +15,8 @@ type TraceConfig struct {
 	TracerConfig   *json.RawMessage       `json:"tracerConfig,omitempty"`
 	Timeout        *string                `json:"timeout,omitempty"`
 	Reexec         *uint64                `json:"reexec,omitempty"`
-	NoRefunds      *bool                  `json:"-"` // Turns off gas refunds when tracing
-	StateOverrides *ethapi.StateOverrides `json:"-"`
+	NoRefunds      *bool                  `json:"noRefunds,omitempty"` // Turns off gas refunds when tracing
+	StateOverrides *ethapi.StateOverrides `json:"stateOverrides,omitempty"`
 
 	BorTraceEnabled *bool
 	BorTx           *bool

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -20,5 +20,5 @@ type TraceConfig struct {
 
 	BorTraceEnabled *bool
 	BorTx           *bool
-	TxIndex         *hexutil.Uint
+	TxIndex         *hexutil.Uint `json:"txIndex,omitempty"`
 }


### PR DESCRIPTION
Json keys are not set for some trace configs(NoRefunds & StateOverrides) so it was not working.