### PR TITLE
Restore reverted changes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-project_name: erigon
+project_name: op-erigon
 
 release:
   disable: false
@@ -50,16 +50,16 @@ builds:
     tags: [ nosqlite, noboltdb, nosilkworm ]
     ldflags: -s -w -extldflags "-static" # We need to build a static binary because we are building in a glibc based system and running in a musl container
 
-  - id: windows-amd64
-    main: ./cmd/erigon
-    binary: erigon
-    goos: [ windows ]
-    goarch: [ amd64 ]
-    env:
-      - CC=x86_64-w64-mingw32-gcc
-      - CXX=x86_64-w64-mingw32-g++
-    tags: [ nosqlite, noboltdb, nosilkworm ]
-    ldflags: -s -w
+#  - id: windows-amd64
+#    main: ./cmd/erigon
+#    binary: erigon
+#    goos: [ windows ]
+#    goarch: [ amd64 ]
+#    env:
+#      - CC=x86_64-w64-mingw32-gcc
+#      - CXX=x86_64-w64-mingw32-g++
+#    tags: [ nosqlite, noboltdb, nosilkworm ]
+#    ldflags: -s -w
 
 
 snapshot:
@@ -67,8 +67,7 @@ snapshot:
 
 dockers:
   - image_templates:
-      - thorax/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/ledgerwatch/{{ .ProjectName }}:{{ .Version }}-amd64
+      - testinprod/{{ .ProjectName }}:{{ .Version }}-amd64
     dockerfile: Dockerfile.release
     use: buildx
     skip_push: true
@@ -79,8 +78,7 @@ dockers:
       - --platform=linux/amd64
 
   - image_templates:
-      - thorax/{{ .ProjectName }}:{{ .Version }}-arm64
-      - ghcr.io/ledgerwatch/{{ .ProjectName }}:{{ .Version }}-arm64
+      - testinprod/{{ .ProjectName }}:{{ .Version }}-arm64
     dockerfile: Dockerfile.release
     skip_push: true
     use: buildx
@@ -91,29 +89,17 @@ dockers:
       - --platform=linux/arm64/v8
 
 docker_manifests:
-  - name_template: thorax/{{ .ProjectName }}:{{ .Version }}
+  - name_template: testinprod/{{ .ProjectName }}:{{ .Version }}
     skip_push: true
     image_templates:
-      - thorax/{{ .ProjectName }}:{{ .Version }}-amd64
-      - thorax/{{ .ProjectName }}:{{ .Version }}-arm64
+      - testinprod/{{ .ProjectName }}:{{ .Version }}-amd64
+      - testinprod/{{ .ProjectName }}:{{ .Version }}-arm64
 
-  - name_template: ghcr.io/ledgerwatch/{{ .ProjectName }}:{{ .Version }}
+  - name_template: testinprod/{{ .ProjectName }}:latest
     skip_push: true
     image_templates:
-      - ghcr.io/ledgerwatch/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/ledgerwatch/{{ .ProjectName }}:{{ .Version }}-arm64
-
-  - name_template: thorax/{{ .ProjectName }}:latest
-    skip_push: true
-    image_templates:
-      - thorax/{{ .ProjectName }}:{{ .Version }}-amd64
-      - thorax/{{ .ProjectName }}:{{ .Version }}-arm64
-
-  - name_template: ghcr.io/ledgerwatch/{{ .ProjectName }}:latest
-    skip_push: true
-    image_templates:
-      - ghcr.io/ledgerwatch/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/ledgerwatch/{{ .ProjectName }}:{{ .Version }}-arm64
+      - testinprod/{{ .ProjectName }}:{{ .Version }}-amd64
+      - testinprod/{{ .ProjectName }}:{{ .Version }}-arm64
 
 announce:
   slack:

--- a/params/version.go
+++ b/params/version.go
@@ -29,24 +29,47 @@ var (
 	GitTag    string
 )
 
+// Version is the version of upstream erigon
 // see https://calver.org
 const (
-	VersionMajor       = 2        // Major version component of the current release
-	VersionMinor       = 38       // Minor version component of the current release
-	VersionMicro       = 0        // Patch version component of the current release
-	VersionModifier    = "stable" // Modifier component of the current release
+	VersionMajor       = 2  // Major version component of the current release
+	VersionMinor       = 56 // Minor version component of the current release
+	VersionMicro       = 2  // Patch version component of the current release
+	VersionModifier    = "" // Modifier component of the current release
 	VersionKeyCreated  = "ErigonVersionCreated"
 	VersionKeyFinished = "ErigonVersionFinished"
 )
 
+// OPVersion is the version of op-erigon
+const (
+	OPVersionMajor    = 0          // Major version component of the current release
+	OPVersionMinor    = 5          // Minor version component of the current release
+	OPVersionMicro    = 0          // Patch version component of the current release
+	OPVersionModifier = "unstable" // Version metadata to append to the version string
+)
+
 // Version holds the textual version string.
 var Version = func() string {
-	return fmt.Sprintf("%d.%02d.%d", VersionMajor, VersionMinor, VersionMicro)
+	return fmt.Sprintf("%d.%02d.%d", OPVersionMajor, OPVersionMinor, OPVersionMicro)
 }()
 
 // VersionWithMeta holds the textual version string including the metadata.
 var VersionWithMeta = func() string {
 	v := Version
+	if OPVersionModifier != "" {
+		v += "-" + OPVersionModifier
+	}
+	return v
+}()
+
+// ErigonVersion holds the textual erigon version string.
+var ErigonVersion = func() string {
+	return fmt.Sprintf("%d.%d.%d", VersionMajor, VersionMinor, VersionMicro)
+}()
+
+// ErigonVersionWithMeta holds the textual erigon version string including the metadata.
+var ErigonVersionWithMeta = func() string {
+	v := ErigonVersion
 	if VersionModifier != "" {
 		v += "-" + VersionModifier
 	}


### PR DESCRIPTION
These changes are unintentionally reverted in the last upstream sync PR(https://github.com/testinprod-io/op-erigon/pull/154).