### PR TITLE
Fix deposit TX's effectiveGasPrice

### DIFF
--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -380,23 +380,8 @@ func (tx DepositTx) IsStarkNet() bool {
 func (tx DepositTx) GetPrice() *uint256.Int  { return uint256.NewInt(0) }
 func (tx DepositTx) GetTip() *uint256.Int    { return uint256.NewInt(0) }
 func (tx DepositTx) GetFeeCap() *uint256.Int { return uint256.NewInt(0) }
-
-// Is this needed at all?
 func (tx DepositTx) GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int {
-	if baseFee == nil {
-		return tx.GetTip()
-	}
-	gasFeeCap := tx.GetFeeCap()
-	// return 0 because effectiveFee cant be < 0
-	if gasFeeCap.Lt(baseFee) {
-		return uint256.NewInt(0)
-	}
-	effectiveFee := new(uint256.Int).Sub(gasFeeCap, baseFee)
-	if tx.GetTip().Lt(effectiveFee) {
-		return tx.GetTip()
-	} else {
-		return effectiveFee
-	}
+	return uint256.NewInt(0)
 }
 
 func (tx DepositTx) Cost() *uint256.Int {

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -770,7 +770,7 @@ func marshalReceipt(receipt *types.Receipt, txn types.Transaction, chainConfig *
 		"logsBloom":         types.CreateBloom(types.Receipts{receipt}),
 	}
 
-	if !chainConfig.IsLondon(header.Number.Uint64()) {
+	if !chainConfig.IsLondon(header.Number.Uint64()) || txn.Type() == types.DepositTxType {
 		fields["effectiveGasPrice"] = hexutil.Uint64(txn.GetPrice().Uint64())
 	} else {
 		baseFee, _ := uint256.FromBig(header.BaseFee)


### PR DESCRIPTION
Resolves #159 

Deposit Tx's have fixed effective gas price of 0, but existing op-erigon code calculates deposit tx's gas price with baseFee. 
This PR sets the effectiveGasPrice to `tx.GetPrice()` which is always 0 for DepositTx. 

op-geth reference: https://github.com/ethereum-optimism/op-geth/blob/da6ea729b858ce854ed4c3dd0979eae0855790c0/core/types/deposit_tx.go#L83-L85

---
Example Result
AS-IS:
```
{"jsonrpc":"2.0","id":1,"result":{"blockHash":"0x2a4fcbf27eeba8dbcc6fdaa3d00ecd1b600ee530af5390ee98d8c4019df3f524",..."effectiveGasPrice":"0xfc"...}
```
TO-BE:
```
{"jsonrpc":"2.0","id":1,"result":{"blockHash":"0x2a4fcbf27eeba8dbcc6fdaa3d00ecd1b600ee530af5390ee98d8c4019df3f524"..."effectiveGasPrice":"0x0"...}
```