### PR TITLE
Make discovery v5 as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ If your chain is the one of `op-mainnet` & `op-sepolia`, or your chain is synced
 **[Optional]** 
 Disables transaction pool gossiping. Though this is not required, it's useful to set this to true since transaction pool gossip is currently unsupported in the Optimism protocol. If not provided, default value is set to `false`.
 
-### `--maxpeers=0`, `--nodiscover`
+### `--maxpeers=0`, `--nodiscover`, `--v5disc=false`
 **[Optional]** 
-Disable P2P. Execution-layer peering is currently not supported in the Optimism protocol. Though this is not required, it saves resources since TX pool gossip is currently not available.
+Disable P2P. This can save resources if you are only using op-node to sync the chain instead of using execution-layer syncing.  
 
 ## Support Chains
 op-erigon supports every OP Stack chains listed in [superchain-registry](https://github.com/ethereum-optimism/superchain-registry).
@@ -134,8 +134,7 @@ $ ./build/bin/erigon \
     --rollup.historicalrpc="https://mainnet.optimism.io" \
     --txpool.gossip.disable=true \
     --chain=op-mainnet \
-    --db.size.limit=8TB \
-    --nodiscover
+    --db.size.limit=8TB
 ```
 2. Use the Docker image: You can get the official Docker image from [testinprod/op-erigon](https://hub.docker.com/r/testinprod/op-erigon).
 3. Use the Helm chart: If you want to deploy op-erigon to the K8S cluster, you can use [Helm chart](https://artifacthub.io/packages/helm/op-charts/erigon).

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -627,7 +627,8 @@ var (
 	}
 	DiscoveryV5Flag = cli.BoolFlag{
 		Name:  "v5disc",
-		Usage: "Enables the experimental RLPx V5 (Topic Discovery) mechanism",
+		Usage: "Enables the experimental RLPx V5 (Topic Discovery) mechanism (enabled by default). Use --v5disc=false to disable it",
+		Value: true,
 	}
 	NetrestrictFlag = cli.StringFlag{
 		Name:  "netrestrict",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -623,7 +623,7 @@ var (
 	}
 	NoDiscoverFlag = cli.BoolFlag{
 		Name:  "nodiscover",
-		Usage: "Disables the peer discovery mechanism (manual peer addition)",
+		Usage: "Disables the v4 peer discovery mechanism (manual peer addition). Refer to --v5disc to configure v5 discovery protocol",
 	}
 	DiscoveryV5Flag = cli.BoolFlag{
 		Name:  "v5disc",


### PR DESCRIPTION
According to [optimism spec](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/exec-engine.md), [disc v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md) is used as a default protocol for peer discovery. 

This PR makes `--v5disc` flag enabled by default. 

For backwards compatibility, v4 is still always enabled unless explicitly set with `--nodiscover` flag. Also, setting `--nodiscover` won't disable v5disc. To completely disable p2p in op-erigon, set both `--nodiscover` and `--v5disc=false`. 

This is useful when using [execution-layer syncing](https://docs.optimism.io/builders/node-operators/management/snap-sync) which will soon be available on op-erigon through p2p staged sync. 