### PR TITLE
Fix gas fee calculation in debug calls

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -23,7 +23,7 @@ import (
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/txpool/txpoolcfg"
 	types2 "github.com/ledgerwatch/erigon-lib/types"
-
+	
 	cmath "github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/common/u256"
 	"github.com/ledgerwatch/erigon/consensus/misc"
@@ -352,7 +352,8 @@ func (st *StateTransition) preCheck(gasBailout bool) error {
 	// Make sure the transaction gasFeeCap is greater than the block's baseFee.
 	if st.evm.ChainRules().IsLondon {
 		// Skip the checks if gas fields are zero and baseFee was explicitly disabled (eth_call)
-		if !st.evm.Config().NoBaseFee || !st.gasFeeCap.IsZero() || !st.tip.IsZero() {
+		skipCheck := st.evm.Config().NoBaseFee && st.gasFeeCap.BitLen() == 0 && st.tip.BitLen() == 0
+		if !skipCheck {
 			if err := CheckEip1559TxGasFeeCap(st.msg.From(), st.gasFeeCap, st.tip, st.evm.Context.BaseFee, st.msg.IsFree()); err != nil {
 				return err
 			}
@@ -367,7 +368,7 @@ func (st *StateTransition) preCheck(gasBailout bool) error {
 			return err
 		}
 		maxFeePerBlobGas := st.msg.MaxFeePerBlobGas()
-		if blobGasPrice.Cmp(maxFeePerBlobGas) > 0 {
+		if !st.evm.Config().NoBaseFee && blobGasPrice.Cmp(maxFeePerBlobGas) > 0 {
 			return fmt.Errorf("%w: address %v, maxFeePerBlobGas: %v blobGasPrice: %v, excessBlobGas: %v",
 				ErrMaxFeePerBlobGas,
 				st.msg.From().Hex(), st.msg.MaxFeePerBlobGas(), blobGasPrice, st.evm.Context.ExcessBlobGas)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -105,6 +105,12 @@ type EVM struct {
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
 // only ever be used *once*.
 func NewEVM(blockCtx evmtypes.BlockContext, txCtx evmtypes.TxContext, state evmtypes.IntraBlockState, chainConfig *chain.Config, vmConfig Config) *EVM {
+	if vmConfig.NoBaseFee {
+		if txCtx.GasPrice.IsZero() {
+			blockCtx.BaseFee = new(uint256.Int)
+		}
+	}
+
 	evm := &EVM{
 		Context:         blockCtx,
 		TxContext:       txCtx,

--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -112,7 +112,7 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *uint256.Int) (type
 			gasFeeCap, gasTipCap = gasPrice, gasPrice
 		} else {
 			// User specified 1559 gas fields (or none), use those
-			gasFeeCap = uint256.MustFromBig(baseFee.ToBig())
+			gasFeeCap = new(uint256.Int)
 			if args.MaxFeePerGas != nil {
 				overflow := gasFeeCap.SetFromBig(args.MaxFeePerGas.ToInt())
 				if overflow {

--- a/turbo/jsonrpc/eth_call.go
+++ b/turbo/jsonrpc/eth_call.go
@@ -207,8 +207,6 @@ func (api *APIImpl) EstimateGas(ctx context.Context, argsOrNil *ethapi2.CallArgs
 		feeCap = args.GasPrice.ToInt()
 	} else if args.MaxFeePerGas != nil {
 		feeCap = args.MaxFeePerGas.ToInt()
-	} else if header.BaseFee != nil {
-		feeCap = new(big.Int).Set(header.BaseFee)
 	} else {
 		feeCap = libcommon.Big0
 	}

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -212,7 +212,7 @@ func ExecuteTraceTx(
 	execCb func(evm *vm.EVM, refunds bool) (*core.ExecutionResult, error),
 ) error {
 	// Run the transaction with tracing enabled.
-	evm := vm.NewEVM(blockCtx, txCtx, ibs, chainConfig, vm.Config{Debug: true, Tracer: tracer})
+	evm := vm.NewEVM(blockCtx, txCtx, ibs, chainConfig, vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})
 
 	var refunds = true
 	if config != nil && config.NoRefunds != nil && *config.NoRefunds {


### PR DESCRIPTION
This PR fixes gas fee calculation for rpc calls. It mostly borrows changes from geth and resolves previously differently-resolved issues. 

- baseFee should not be used as a default value for gasFeeCap when gasFee/gasTip fields hasn't be set. 
  - Instead, baseFee is used for validating whether the final gas fee + gas tip is higher than basFee
  - Setting gasFeeCap to baseFee will prevent calling eth_estimateGas with 0-balance accounts because the account's balance has to be bigger than the baseFee. 
- For debug RPC calls, we should set evm.Config().NoBaseFee to true
  - Also, we should set blockCtx.BaseFee = 0 when NoBaseFee is true, because we want to skip comparing gasFeeCap with the real baseFee when it's for debug calls. 
  - This allows calling rpcs like eth_estimateGas debug_traceCall with accounts that have 0 balance. 

Fixes https://github.com/testinprod-io/op-erigon/issues/183