### PR TITLE
Temporarily disable govet-copylocks linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,7 @@ linters-settings:
       - fieldalignment
       - shadow
       - unsafeptr
+      - copylocks #TODO: [https://github.com/testinprod-io/op-erigon/issues/117] enable me after https://github.com/ledgerwatch/erigon/pull/9977 is merged
   goconst:
     min-len: 2
     min-occurrences: 2


### PR DESCRIPTION
This is a follow-up PR for https://github.com/testinprod-io/op-erigon/issues/117 and https://github.com/testinprod-io/op-erigon/pull/135.

We have to enable govet copylocks linter after https://github.com/ledgerwatch/erigon/pull/9977 is merged in the upstream repo.