### PR TITLE
Add empty uint256 to st.emv.BlobFee

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -303,6 +303,7 @@ func (st *StateTransition) preCheck(gasBailout bool) error {
 		// Gas is free, but no refunds!
 		st.initialGas = st.msg.Gas()
 		st.gasRemaining += st.msg.Gas() // Add gas here in order to be able to execute calls.
+		st.evm.BlobFee = new(uint256.Int)
 		// Don't touch the gas pool for system transactions
 		if st.msg.IsSystemTx() {
 			if st.evm.ChainConfig().IsOptimismRegolith(st.evm.Context.Time) {


### PR DESCRIPTION
Add empty uint256 to st.emv.BlobFee for DepositTx because deposit tx doesn't pay gas on L2. Without this, st.emv.BlobFee is nil in https://github.com/testinprod-io/op-erigon/blob/782c79d601f6f32ecfb7cdf313d3e76e48819e8e/eth/tracers/native/prestate.go#L119, which causes rpc crash. 

Resolves https://github.com/testinprod-io/op-erigon/issues/223