### PR TITLE
Skip withdrawals hash check in body hash calculation after isthmus fork

### DIFF
--- a/eth/stagedsync/stage_bodies.go
+++ b/eth/stagedsync/stage_bodies.go
@@ -162,7 +162,7 @@ func BodiesForward(
 		for loopCount := 0; loopCount == 0 || (req != nil && sentToPeer && loopCount < requestLoopCutOff); loopCount++ {
 			start := time.Now()
 			currentTime := uint64(time.Now().Unix())
-			req, err = cfg.bd.RequestMoreBodies(tx, cfg.blockReader, currentTime, cfg.blockPropagator)
+			req, err = cfg.bd.RequestMoreBodies(tx, cfg.blockReader, currentTime, cfg.blockPropagator, &cfg.chanConfig)
 			if err != nil {
 				return false, fmt.Errorf("request more bodies: %w", err)
 			}

--- a/turbo/engineapi/engine_block_downloader/body.go
+++ b/turbo/engineapi/engine_block_downloader/body.go
@@ -73,7 +73,7 @@ func (e *EngineBlockDownloader) downloadAndLoadBodiesSyncronously(ctx context.Co
 		for loopCount := 0; loopCount == 0 || (req != nil && sentToPeer && loopCount < requestLoopCutOff); loopCount++ {
 			start := time.Now()
 			currentTime := uint64(time.Now().Unix())
-			req, err = e.bd.RequestMoreBodies(tx, e.blockReader, currentTime, e.blockPropagator)
+			req, err = e.bd.RequestMoreBodies(tx, e.blockReader, currentTime, e.blockPropagator, e.config)
 			if err != nil {
 				return false, fmt.Errorf("request more bodies: %w", err)
 			}

--- a/turbo/stages/bodydownload/body_algos.go
+++ b/turbo/stages/bodydownload/body_algos.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/erigontech/erigon-lib/chain"
 	"math/big"
 
 	"github.com/holiman/uint256"
@@ -37,6 +38,7 @@ func (bd *BodyDownload) UpdateFromDb(db kv.Tx) (headHeight, headTime uint64, hea
 	// Resetting for requesting a new range of blocks
 	bd.requestedLow = bodyProgress + 1
 	bd.requestedMap = make(map[BodyHashes]uint64)
+	bd.withdrawalsHashMap = make(map[BodyHashes][]byte)
 	bd.delivered.Clear()
 	bd.deliveredCount = 0
 	bd.wastedCount = 0
@@ -74,7 +76,7 @@ func (bd *BodyDownload) UpdateFromDb(db kv.Tx) (headHeight, headTime uint64, hea
 }
 
 // RequestMoreBodies - returns nil if nothing to request
-func (bd *BodyDownload) RequestMoreBodies(tx kv.RwTx, blockReader services.FullBlockReader, currentTime uint64, blockPropagator adapter.BlockPropagator) (*BodyRequest, error) {
+func (bd *BodyDownload) RequestMoreBodies(tx kv.RwTx, blockReader services.FullBlockReader, currentTime uint64, blockPropagator adapter.BlockPropagator, chainCfg *chain.Config) (*BodyRequest, error) {
 	var bodyReq *BodyRequest
 	blockNums := make([]uint64, 0, bd.blockBufferSize)
 	hashes := make([]libcommon.Hash, 0, bd.blockBufferSize)
@@ -141,8 +143,13 @@ func (bd *BodyDownload) RequestMoreBodies(tx kv.RwTx, blockReader services.FullB
 			}
 		}
 		if request {
-			if header.UncleHash == types.EmptyUncleHash && header.TxHash == types.EmptyRootHash &&
-				(header.WithdrawalsHash == nil || *header.WithdrawalsHash == types.EmptyRootHash) {
+			invalidUncleHash := header.UncleHash == types.EmptyUncleHash
+			invalidTxHash := header.TxHash == types.EmptyRootHash
+			emptyWithdrawalsHash := header.WithdrawalsHash != nil && *header.WithdrawalsHash == types.EmptyRootHash
+			skipCheckOnIsthmus := chainCfg != nil && chainCfg.IsOptimismIsthmus(header.Time)
+			if invalidUncleHash &&
+				invalidTxHash &&
+				(header.WithdrawalsHash == nil || (emptyWithdrawalsHash && !skipCheckOnIsthmus)) {
 				// Empty block body
 				body := &types.RawBody{}
 				if header.WithdrawalsHash != nil {
@@ -166,10 +173,12 @@ func (bd *BodyDownload) RequestMoreBodies(tx kv.RwTx, blockReader services.FullB
 			var bodyHashes BodyHashes
 			copy(bodyHashes[:], header.UncleHash.Bytes())
 			copy(bodyHashes[length.Hash:], header.TxHash.Bytes())
-			if header.WithdrawalsHash != nil {
-				copy(bodyHashes[2*length.Hash:], header.WithdrawalsHash.Bytes())
-			}
 			bd.requestedMap[bodyHashes] = blockNum
+
+			if header.WithdrawalsHash != nil && (chainCfg == nil || !chainCfg.IsOptimismIsthmus(header.Time)) {
+				withdrawalsHash := header.WithdrawalsHash.Bytes()
+				bd.withdrawalsHashMap[bodyHashes] = withdrawalsHash
+			}
 			blockNums = append(blockNums, blockNum)
 			hashes = append(hashes, hash)
 		} else {
@@ -303,10 +312,6 @@ Loop:
 			copy(bodyHashes[:], uncleHash.Bytes())
 			txHash := types.DeriveSha(RawTransactions(txs[i]))
 			copy(bodyHashes[length.Hash:], txHash.Bytes())
-			if withdrawals[i] != nil {
-				withdrawalsHash := types.DeriveSha(withdrawals[i])
-				copy(bodyHashes[2*length.Hash:], withdrawalsHash.Bytes())
-			}
 
 			// Block numbers are added to the bd.delivered bitmap here, only for blocks for which the body has been received, and their double hashes are present in the bd.requestedMap
 			// Also, block numbers can be added to bd.delivered for empty blocks, above
@@ -315,13 +320,25 @@ Loop:
 				undelivered++
 				continue
 			}
+
+			if withdrawals[i] != nil {
+				if requestedHash, ok := bd.withdrawalsHashMap[bodyHashes]; ok {
+					withdrawalsHash := types.DeriveSha(withdrawals[i])
+					if !bytes.Equal(requestedHash, withdrawalsHash.Bytes()) {
+						undelivered++
+						continue
+					}
+				}
+			}
+
 			//deliveredNums = append(deliveredNums, blockNum)
 			if req, ok := bd.requests[blockNum]; ok {
 				for _, blockNum := range req.BlockNums {
 					toClean[blockNum] = struct{}{}
 				}
 			}
-			delete(bd.requestedMap, bodyHashes) // Delivered, cleaning up
+			delete(bd.requestedMap, bodyHashes)       // Delivered, cleaning up
+			delete(bd.withdrawalsHashMap, bodyHashes) // Delivered, cleaning up
 
 			bd.addBodyToCache(blockNum, &types.RawBody{Transactions: txs[i], Uncles: uncles[i], Withdrawals: withdrawals[i]})
 			bd.delivered.Add(blockNum)

--- a/turbo/stages/bodydownload/body_data_struct.go
+++ b/turbo/stages/bodydownload/body_data_struct.go
@@ -5,15 +5,14 @@ import (
 	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/length"
 	"github.com/erigontech/erigon-lib/log/v3"
-	"github.com/erigontech/erigon/turbo/services"
-	"github.com/google/btree"
-
 	"github.com/erigontech/erigon/consensus"
 	"github.com/erigontech/erigon/core/types"
+	"github.com/erigontech/erigon/turbo/services"
+	"github.com/google/btree"
 )
 
 // BodyHashes is to be used for the mapping between TxHash, UncleHash, and WithdrawalsHash to the block header
-type BodyHashes [3 * length.Hash]byte
+type BodyHashes [2 * length.Hash]byte
 
 const MaxBodiesInRequest = 1024
 
@@ -34,25 +33,26 @@ type BodyTreeItem struct {
 
 // BodyDownload represents the state of body downloading process
 type BodyDownload struct {
-	peerMap          map[[64]byte]int
-	requestedMap     map[BodyHashes]uint64
-	DeliveryNotify   chan struct{}
-	deliveryCh       chan Delivery
-	Engine           consensus.Engine
-	delivered        *roaring64.Bitmap
-	prefetchedBlocks *PrefetchedBlocks
-	deliveriesH      map[uint64]*types.Header
-	requests         map[uint64]*BodyRequest
-	maxProgress      uint64
-	requestedLow     uint64 // Lower bound of block number for outstanding requests
-	deliveredCount   float64
-	wastedCount      float64
-	bodyCache        *btree.BTreeG[BodyTreeItem]
-	bodyCacheSize    int
-	bodyCacheLimit   int // Limit of body Cache size
-	blockBufferSize  int
-	br               services.FullBlockReader
-	logger           log.Logger
+	peerMap            map[[64]byte]int
+	requestedMap       map[BodyHashes]uint64
+	withdrawalsHashMap map[BodyHashes][]byte
+	DeliveryNotify     chan struct{}
+	deliveryCh         chan Delivery
+	Engine             consensus.Engine
+	delivered          *roaring64.Bitmap
+	prefetchedBlocks   *PrefetchedBlocks
+	deliveriesH        map[uint64]*types.Header
+	requests           map[uint64]*BodyRequest
+	maxProgress        uint64
+	requestedLow       uint64 // Lower bound of block number for outstanding requests
+	deliveredCount     float64
+	wastedCount        float64
+	bodyCache          *btree.BTreeG[BodyTreeItem]
+	bodyCacheSize      int
+	bodyCacheLimit     int // Limit of body Cache size
+	blockBufferSize    int
+	br                 services.FullBlockReader
+	logger             log.Logger
 }
 
 // BodyRequest is a sketch of the request for block bodies, meaning that access to the database is required to convert it to the actual BlockBodies request (look up hashes of canonical blocks)
@@ -66,13 +66,14 @@ type BodyRequest struct {
 // NewBodyDownload create a new body download state object
 func NewBodyDownload(engine consensus.Engine, blockBufferSize, bodyCacheLimit int, br services.FullBlockReader, logger log.Logger) *BodyDownload {
 	bd := &BodyDownload{
-		requestedMap:     make(map[BodyHashes]uint64),
-		bodyCacheLimit:   bodyCacheLimit,
-		delivered:        roaring64.New(),
-		deliveriesH:      make(map[uint64]*types.Header),
-		requests:         make(map[uint64]*BodyRequest),
-		peerMap:          make(map[[64]byte]int),
-		prefetchedBlocks: NewPrefetchedBlocks(),
+		requestedMap:       make(map[BodyHashes]uint64),
+		withdrawalsHashMap: make(map[BodyHashes][]byte),
+		bodyCacheLimit:     bodyCacheLimit,
+		delivered:          roaring64.New(),
+		deliveriesH:        make(map[uint64]*types.Header),
+		requests:           make(map[uint64]*BodyRequest),
+		peerMap:            make(map[[64]byte]int),
+		prefetchedBlocks:   NewPrefetchedBlocks(),
 		// DeliveryNotify has capacity 1, and it is also used so that senders never block
 		// This makes this channel a mailbox with no more than one letter in it, meaning
 		// that there is something to collect


### PR DESCRIPTION
After the latest isthmus fork, we can skip the withdrawalsHash verification during p2p sync: https://specs.optimism.io/protocol/isthmus/exec-engine.html#p2p
<img width="790" alt="Screenshot 2025-04-17 at 11 41 29 PM" src="https://github.com/user-attachments/assets/7c96ec42-fbf6-4433-84bf-ccc372a9655f" />


This PR updates `turbo/stages/bodydownload/body_algos.go` to skip checking for withdrawalsHash after isthmus fork. 
When downloading block bodies during p2p sync, erigon keeps a map of requestedMap, which will store the expected block body hash, then check for the map when erigon receives a response from its peer. 

However, since we don't know the hardfork status when receiving the block body, we need a way to identify that the request itself doesn't need withdrawalsHash checked. 

So, this PR will add a new `withdrawalsHashMap`. When isthmus is not enabled and there is withdrawalsHash in the header, it will add a index to the `withdrawalsHashMap`. after isthmus, this field will not be set. When receiving a block body through p2p, it will check the `withdrawalsHashMap`. If there is no value in the map, we know that the requester doesn't want the withdrawalsHash checked. 