### PR TITLE
Fix receipt derive logic for systemTx

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -639,6 +639,10 @@ func (r Receipts) DeriveFields(config *chain.Config, hash libcommon.Hash, number
 		}
 	}
 	if config.IsOptimismBedrock(number) && len(txs) >= 2 { // need at least an info tx and a non-info tx
+		if txs[len(txs)-1].Type() == DepositTxType {
+			return nil
+		}
+
 		gasParams, err := opstack.ExtractL1GasParams(config, time, txs[0].GetData())
 		if err != nil {
 			return err

--- a/eth/ethutils/receipt.go
+++ b/eth/ethutils/receipt.go
@@ -56,6 +56,8 @@ func MarshalReceipt(
 
 	if !chainConfig.IsLondon(header.Number.Uint64()) {
 		fields["effectiveGasPrice"] = (*hexutil.Big)(txn.GetPrice().ToBig())
+	} else if txn.Type() == types.DepositTxType {
+		fields["effectiveGasPrice"] = (*hexutil.Big)(big.NewInt(0))
 	} else {
 		baseFee, _ := uint256.FromBig(header.BaseFee)
 		gasPrice := new(big.Int).Add(header.BaseFee, txn.GetEffectiveGasTip(baseFee).ToBig())

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -82,19 +82,22 @@ func (api *BaseAPI) getReceipts(ctx context.Context, tx kv.Tx, block *types.Bloc
 		}
 
 		if header.Number != nil && chainConfig.IsOptimismBedrock(header.Number.Uint64()) {
-			gasParams, err := opstack.ExtractL1GasParams(chainConfig, header.Time, block.Transactions()[0].GetData())
-
-			var daFootprintGasScalar uint64
-			isJovian := chainConfig.IsJovian(header.Time)
-			if isJovian {
-				scalar, err := opstack.ExtractDAFootprintGasScalar(txn.GetData())
+			if txn.Type() != types.DepositTxType {
+				gasParams, err := opstack.ExtractL1GasParams(chainConfig, header.Time, block.Transactions()[0].GetData())
 				if err != nil {
-					return nil, fmt.Errorf("failed to extract DA footprint gas scalar: %w", err)
+					return nil, err
 				}
-				daFootprintGasScalar = uint64(scalar)
-			}
 
-			if err == nil && txn.Type() != types.DepositTxType {
+				var daFootprintGasScalar uint64
+				isJovian := chainConfig.IsJovian(header.Time)
+				if isJovian {
+					scalar, err := opstack.ExtractDAFootprintGasScalar(txn.GetData())
+					if err != nil {
+						return nil, fmt.Errorf("failed to extract DA footprint gas scalar: %w", err)
+					}
+					daFootprintGasScalar = uint64(scalar)
+				}
+
 				receipt.L1GasPrice = gasParams.L1BaseFee.ToBig()
 				rcd := txn.RollupCostData()
 				l1Fee, l1GasUsed := gasParams.CostFunc(rcd)

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -91,7 +91,7 @@ func (api *BaseAPI) getReceipts(ctx context.Context, tx kv.Tx, block *types.Bloc
 				var daFootprintGasScalar uint64
 				isJovian := chainConfig.IsJovian(header.Time)
 				if isJovian {
-					scalar, err := opstack.ExtractDAFootprintGasScalar(txn.GetData())
+					scalar, err := opstack.ExtractDAFootprintGasScalar(block.Transactions()[0].GetData())
 					if err != nil {
 						return nil, fmt.Errorf("failed to extract DA footprint gas scalar: %w", err)
 					}


### PR DESCRIPTION
This PR changes the receipt deriving logic to match op-geth, which is to skip optimism transaction receipt parsing logic for deposit/system transactions. 
This is especially important in jovian activation block, where there is only deposit transactions in the block as per [spec](https://specs.optimism.io/protocol/jovian/derivation.html). However, previous we attempt to parse l1 attributes data for a block that only has system transactions. 